### PR TITLE
Allow city to be passed by adapter

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -67,7 +67,7 @@ var getAndSaveData = function (source) {
       _.forEach(data.measurements, function (m) {
         m.location = m.location || data.name; // use existing location if it exists
         m.country = source.country;
-        m.city = source.city;
+        m.city = m.city || source.city; // use city from measurement, otherwise default to source
         m.sourceName = source.name;
         bulk.insert(m);
       });


### PR DESCRIPTION
With this PR, the adapter can set a city for each measurement. If there is no city for a measurement, it will default to the one defined in the source. This PR should not introduce a breaking change.

This is useful for the Dutch source (#25). This source is a single HTML table, containing data for many cities.

cc @jflasher 
