### PR TITLE
Improve way moment.locale is set on Dutch adapter

### DIFF
--- a/adapters/netherlands.js
+++ b/adapters/netherlands.js
@@ -5,7 +5,6 @@ var _ = require('lodash');
 var cheerio = require('cheerio');
 var async = require('async');
 var moment = require('moment-timezone');
-moment.locale('nl');
 
 exports.name = 'netherlands';
 
@@ -66,7 +65,7 @@ var listApachetree = function (data, url) {
   var $ = cheerio.load(data);
 
   var parseDate = function (ds) {
-    var date = moment.tz(ds, 'DD-MMM-YYYY HH:mm', 'Europe/Amsterdam');
+    var date = moment.tz(ds, 'DD-MMM-YYYY HH:mm', 'nl', 'Europe/Amsterdam');
     return date.toDate();
   };
 


### PR DESCRIPTION
Setting locale using moment.locale('nl') sets it globally, affecting other adapters as well. HT @anandthakker

The existing Australian measurements should be removed from the db, or updated to reflect this change. Removing might be the easiest, since there's not a whole lot of data to begin with.

cc @jflasher 
