### PR TITLE
Don't insert measurements from more than a few days ago

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
   - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
   - echo "deb http://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.0.list
   - sudo apt-get update
-  - sudo apt-get install -y mongodb-org=3.0.6 mongodb-org-server=3.0.6 mongodb-org-shell=3.0.6 mongodb-org-mongos=3.0.6 mongodb-org-tools=3.0.6
+  - sudo apt-get install -y --force-yes mongodb-org=3.0.6 mongodb-org-server=3.0.6 mongodb-org-shell=3.0.6 mongodb-org-mongos=3.0.6 mongodb-org-tools=3.0.6
   - sleep 15 #mongo may not be responded directly. See http://docs.travis-ci.com/user/database-setup/#MongoDB
   - mongo --version
 after_success:

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var _ = require('lodash');
+var moment = require('moment-timezone');
 
 /**
  * Make sure that the data format is what the platform is expecting.
@@ -54,6 +55,12 @@ exports.pruneMeasurements = function (measurements) {
 
     // Make sure date is present and valid
     if (m.date === undefined || m.date instanceof Date === false) {
+      return false;
+    }
+
+    // Make sure date is within the last few days to prevent accidents
+    var duration = moment.duration(moment().diff(moment(m.date))).asDays();
+    if (duration > 3) {
       return false;
     }
 

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -25,19 +25,19 @@ describe('Testing helper functions', function () {
         name: 'test',
         measurements: [
           {
-            parameter: 324,
+            parameter: 324, // Bad param, unit, value
             unit: 234,
             value: 'asd',
             date: new Date()
           },
           {
-            parameter: 'pm25',
+            parameter: 'pm25', // Bad unit
             unit: 'ppb',
             value: 234,
             date: new Date()
           },
           {
-            parameter: 'pm25',
+            parameter: 'pm25', // Bad coords
             unit: 'ppm',
             value: 234,
             coordinates: {
@@ -46,10 +46,16 @@ describe('Testing helper functions', function () {
             date: new Date()
           },
           {
-            parameter: 'pm25',
+            parameter: 'pm25',  // Bad unit
             unit: 'µg/m3',
             value: 20,
             date: new Date()
+          },
+          {
+            parameter: 'pm25',  // Date too far in past
+            unit: 'µg/m3',
+            value: 20,
+            date: new Date(new Date().setDate(new Date().getDate() - 5))
           }
         ]
       };


### PR DESCRIPTION
This should not insert items that are more than 3 days in the past. Manual data imports should be unaffected by this. @olafveerman let me know what you think.
