### PR TITLE
Handling CSV limits better

### DIFF
--- a/api/routes/measurements.js
+++ b/api/routes/measurements.js
@@ -105,7 +105,11 @@ module.exports = [
         // Set a different max limit for CSVs to get a lot of data, but not
         // all of it, because that's just crazy. Setting to 65,536 since this
         // is the Excel limit from a while back and is as good as anything.
-        request.limit = Math.min(request.limit, 65536);
+
+        // This gets a bit weird since we want to honor any orig set limit,
+        // regardless of what was just set above
+        let limit = request.url.query.limit || 65536;
+        request.limit = Math.min(limit, 65536);
       }
       params = _.omit(params, 'format');
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -127,6 +127,18 @@ describe('Testing endpoints', function () {
       });
     });
 
+    it('should return all entries in csv when no limit is set', function (done) {
+      request(self.baseURL + 'measurements?format=csv', function (err, response, body) {
+        if (err) {
+          console.error(err);
+        }
+
+        var lines = body.split('\n');
+        expect(lines.length).to.equal(102);
+        done();
+      });
+    });
+
     it('should respect limit parameter for csv', function (done) {
       request(self.baseURL + 'measurements?limit=10&format=csv', function (err, response, body) {
         if (err) {


### PR DESCRIPTION
Should now properly handle user set limits, but default to larger size
