### PR TITLE
[WIP] Add /sources endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*~
 node_modules
 .env
 npm-debug.log

--- a/api/controllers/sources.js
+++ b/api/controllers/sources.js
@@ -1,0 +1,71 @@
+'use strict';
+
+import { filter, has } from 'lodash';
+
+import { db } from '../services/db';
+import { AggregationEndpoint } from './base';
+
+// Generate intermediate aggregated result
+let resultsQuery = db
+                      .from('measurements')
+                      .select('country', 'source_name as sourceName')
+                      .select(db.raw('count(distinct location) as locations'))
+                      .count('value')
+                      .orderBy('country')
+                      .groupBy('country', 'sourceName');
+
+// Create the endpoint from the class
+let sources = new AggregationEndpoint('SOURCES', resultsQuery, filterResultsForQuery, groupResults);
+
+/**
+ * Query the database and recieve back somewhat aggregated results
+ *
+ * @params {function} cb Callback of form (err, results)
+ */
+export function queryDatabase (cb) {
+  sources.queryDatabase(cb);
+}
+
+/**
+* Query distinct sources. Implements all protocols supported by /sources endpoint
+*
+* @param {Object} query - Payload contains query paramters and their values
+* @param {recordsCallback} cb - The callback that returns the records
+*/
+export function query (query, redis, cb) {
+  sources.query(query, redis, cb);
+}
+
+/**
+ * Filter over larger results set to get only get specific values if requested
+ *
+ * @param {array} results Results array from database query or cache
+ * @param {object} query Query object from Hapi
+ * @returns {array} An array of filtered results
+ * @todo this could be better optimized for sure
+ */
+function filterResultsForQuery (results, query) {
+  if (has(query, 'country')) {
+    results = filter(results, (r) => {
+      return r.country === query.country;
+    });
+  }
+
+  return results;
+}
+
+/**
+* This is a big ugly function to group the results from the db into something
+* nicer for display.
+*
+* @param {Array} results - The db aggregation results
+*/
+function groupResults (results) {
+  // Convert numbers to Numbers
+  return results.map((r) => {
+    r.locations = Number(r.locations);
+    r.count = Number(r.count);
+
+    return r;
+  });
+}

--- a/api/routes/sources.js
+++ b/api/routes/sources.js
@@ -1,0 +1,76 @@
+'use strict';
+
+var Boom = require('boom');
+var m = require('../controllers/sources.js');
+import { log } from '../services/logger';
+
+/**
+ * @api {get} /sources GET
+ * @apiGroup Sources
+ * @apiDescription Provides a simple listing of sources within the platform.
+ *
+ * @apiParam {string} [country] Limit results by a certain country.
+ *
+ * @apiSuccess {string}   country     Country containing city, in 2 letter ISO code
+ * @apiSuccess {string}   sourceName  Source name identifier
+ * @apiSuccess {number}   locations   Number of locations in this city
+ * @apiSuccess {number}   count       Number of measurements for this city
+ * @apiSuccessExample {json} Success Response:
+ *
+ *   [
+ *     {
+ *       "country": "MN",
+ *       "sourceName": "Agaar.mn",
+ *       "locations": 9,
+ *       "count": 21301
+ *     },
+ *     {
+ *       "country": "MN",
+ *       "sourceName": "StateAir_Ulaanbaatar",
+ *       "locations": 1,
+ *       "count": 2326
+ *     },
+ *     ...
+ *   ]
+ *
+ * @apiError statusCode     The error code
+ * @apiError error          Error name
+ * @apiError message        Error message
+ * @apiErrorExample {json} Error Response:
+ *     HTTP/1.1 400 Bad Request
+ *     {
+ *      "statusCode": 400,
+ *      "error": "Bad Request",
+ *      "message": "Oops!"
+ *     }
+ */
+
+module.exports = [
+  {
+    method: ['GET'],
+    path: '/v1/sources',
+    handler: function (request, reply) {
+      var params = {};
+
+      // For GET
+      if (request.query) {
+        params = request.query;
+      }
+
+      // Don't use a limit for this endpoint
+      request.limit = undefined;
+
+      // Handle it
+      var redis = request.server.plugins['hapi-redis'].client;
+      m.query(params, redis, function (err, records, count) {
+        if (err) {
+          log(['error'], err);
+          return reply(Boom.badImplementation(err));
+        }
+
+        request.count = count;
+        return reply(records);
+      });
+    }
+  }
+];

--- a/api/services/server.js
+++ b/api/services/server.js
@@ -72,7 +72,8 @@ Server.prototype.start = function (redisURL, cb) {
         '/v1/latest',
         '/v1/cities',
         '/v1/countries',
-        '/v1/fetches'
+        '/v1/fetches',
+        '/v1/sources'
       ]
     }
   }, function (err) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -66,7 +66,8 @@ describe('Testing endpoints', function () {
           'fetches',
           'latest',
           'locations',
-          'measurements'
+          'measurements',
+          'sources'
         ];
 
         var res = JSON.parse(body);
@@ -303,7 +304,7 @@ describe('Testing endpoints', function () {
     });
 
     it('has a meta block', function (done) {
-      request(self.baseURL + 'latest', function (err, response, body) {
+      request(self.baseURL + 'fetches', function (err, response, body) {
         if (err) {
           console.error(err);
         }
@@ -312,11 +313,29 @@ describe('Testing endpoints', function () {
         var testMeta = { name: 'openaq-api',
           license: 'CC BY 4.0',
           website: 'https://docs.openaq.org/',
-          found: 57,
+          found: 3,
           page: 1,
           limit: 100
         };
         expect(res.meta).to.deep.equal(testMeta);
+        done();
+      });
+    });
+  });
+
+  describe('/sources', function () {
+    it('should return properly', function (done) {
+      request(self.baseURL + 'sources', function (err, response, body) {
+        if (err) {
+          console.error(err);
+        }
+
+        var res = JSON.parse(body);
+        expect(res.results.length).to.equal(8);
+        expect(res.results[0].country).to.be.an('string');
+        expect(res.results[0].sourceName).to.be.a('string');
+        expect(res.results[0].locations).to.be.a('number');
+        expect(res.results[0].count).to.be.a('number');
         done();
       });
     });


### PR DESCRIPTION
#173

I've added a `/sources` endpoint that's based off of `cities`. It has `sourceName`, `country`, `locations` and `count` fields.

I guess you want a new `sourceUrl` field on both `/sources` and `/measurements`? I'm only seeing URLs in `attribution`. How do you want to handle that?

PS: Fixed the meta check in fetches test.
