### PR TITLE
Include Kosovo in country list

### DIFF
--- a/lib/country-list.json
+++ b/lib/country-list.json
@@ -476,6 +476,10 @@
 "Code": "KR"
 },
 {
+"Name": "Kosovo",
+"Code": "XK"
+},
+{
 "Name": "Kuwait",
 "Code": "KW"
 },


### PR DESCRIPTION
![screenshot from 2016-04-18 18 33 13](https://cloud.githubusercontent.com/assets/194381/14599738/aa669248-058b-11e6-9baa-00ca53a45447.png)

As we're using the temporary country code XK in the adapter, I thought it should get a corresponding name in the list.
