### PR TITLE
include_fields is ignored in CSV responses

### DIFF
--- a/api/routes/measurements.js
+++ b/api/routes/measurements.js
@@ -133,9 +133,10 @@ module.exports = [
         }
 
         if (formatForCSV) {
+          var columns = ['location', 'city', 'country', 'utc', 'local', 'parameter', 'value', 'unit'];
           var options = {
             header: true,
-            columns: ['location', 'city', 'country', 'utc', 'local', 'parameter', 'value', 'unit', 'attribution']
+            columns: columns.concat(params.include_fields.split(','))
           };
 
           records = records.map(function (r) {


### PR DESCRIPTION
On the measurements endpoint, when you set `include_fields=attribution,averagingPeriod,sourceName` along with `format=csv`, fields other than `attribution` is not being exported in the CSV file. `api/routes/measurements.js` shows that the columns were hardcoded.
