### PR TITLE
Some clarifications in api docs

### DIFF
--- a/api/routes/locations.js
+++ b/api/routes/locations.js
@@ -14,8 +14,8 @@ import { log } from '../services/logger';
  * @apiParam {string} [location] Limit results by a certain location.
  * @apiParam {string=pm25, pm10, so2, no2, o3, co, bc} [parameter] Limit to only a certain parameter.
  * @apiParam {boolean} [has_geo] Filter out items that have or do not have geographic information.
- * @apiParam {string} [coordinates] Center point (`lat, lon`) used to get measurements within a certain area. (ex. `coordinates=40.23,34.17`)
- * @apiParam {number} [radius=2500] Radius (in meters) used to get measurements within a certain area, must be used with `coordinates`.
+ * @apiParam {string} [coordinates] Center point (`lat, lon`) used to get locations within a certain area. (ex. `coordinates=40.23,34.17`)
+ * @apiParam {number} [radius=2500] Radius (in meters) used to get locations within a certain area, must be used with `coordinates`.
  * @apiParam {number} [limit=100] Change the number of results returned, max is 1000.
  * @apiParam {number} [page=1] Paginate through results.
  *

--- a/api/routes/measurements.js
+++ b/api/routes/measurements.js
@@ -20,8 +20,8 @@ import { log } from '../services/logger';
  * @apiParam {number} [radius=2500] Radius (in meters) used to get measurements within a certain area, must be used with `coordinates`.
  * @apiParam {number} [value_from] Show results above value threshold, useful in combination with `parameter`.
  * @apiParam {number} [value_to] Show results below value threshold, useful in combination with `parameter`.
- * @apiParam {string} [date_from] Show results after a certain date. (ex. `2015-12-20`)
- * @apiParam {string} [date_to] Show results before a certain date. (ex. `2015-12-20`)
+ * @apiParam {string} [date_from] Show results after a certain date. This acts on the `utc` timestamp of each measurement. (ex. `2015-12-20`, or `2015-12-20T09:00:00`)
+ * @apiParam {string} [date_to] Show results before a certain date. This acts on the `utc` timestamp of each measurement. (ex. `2015-12-20`, or `2015-12-20T09:00:00`)
  * @apiParam {string} [sort=desc] The sort order, asc or desc. Must be used with `order_by`.
  * @apiParam {string} [order_by=date] Field to sort by. Must be used with `sort`.
  * @apiParam {array=attribution, averagingPeriod, sourceName}  [include_fields] Include extra fields in the output in addition to default values.


### PR DESCRIPTION
Most importantly clarifies that the date filter works on the `utc` timestamp, and that it's possible to specify a time.
