### PR TITLE
Allow multiple values to be specified on locations endpoint

### DIFF
--- a/api/controllers/base.js
+++ b/api/controllers/base.js
@@ -26,7 +26,7 @@ export class AggregationEndpoint {
   }
 
   /**
-   * Query the database and recieve back somewhat aggregated results
+   * Query the database and receive back somewhat aggregated results
    *
    * @params {function} cb Callback of form (err, results)
    */
@@ -43,7 +43,7 @@ export class AggregationEndpoint {
   /**
   * Runs the query.
   *
-  * @param {Object} query - Payload contains query paramters and their values
+  * @param {Object} query - Payload contains query parameters and their values
   * @param {integer} page - Page number
   * @param {integer} limit - Items per page
   * @param {recordsCallback} cb - The callback that returns the records
@@ -58,7 +58,7 @@ export class AggregationEndpoint {
       cb(null, paged, data.length);
     };
 
-    // Check to see if we have the intermeditate aggregation result cached, use
+    // Check to see if we have the intermediate aggregation result cached, use
     // if it's there
     if (redis && redis.ready) {
       redis.get(this.cacheName, (err, reply) => {

--- a/api/controllers/locations.js
+++ b/api/controllers/locations.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { filter, has, groupBy, forEach, unique } from 'lodash';
+import { filter, has, groupBy, forEach, unique, includes } from 'lodash';
 import distance from 'turf-distance';
 import point from 'turf-point';
 
@@ -76,34 +76,22 @@ function handleDataMapping (results) {
  */
 function filterResultsForQuery (results, query) {
   if (has(query, 'city')) {
-    results = filter(results, (r) => {
-      return r.city === query.city;
-    });
+    results = filter(results, (r) => includes(query.city, r.city));
   }
   if (has(query, 'country')) {
-    results = filter(results, (r) => {
-      return r.country === query.country;
-    });
+    results = filter(results, (r) => includes(query.country, r.country));
   }
   if (has(query, 'location')) {
-    results = filter(results, (r) => {
-      return r.location === query.location;
-    });
+    results = filter(results, (r) => includes(query.location, r.location));
   }
   if (has(query, 'parameter')) {
-    results = filter(results, (r) => {
-      return r.parameter === query.parameter;
-    });
+    results = filter(results, (r) => includes(query.parameter, r.parameter));
   }
   if (has(query, 'has_geo')) {
     if (query.has_geo === false || query.has_geo === 'false') {
-      results = filter(results, (r) => {
-        return !r.coordinates;
-      });
+      results = filter(results, (r) => !r.coordinates);
     } else {
-      results = filter(results, (r) => {
-        return !!r.coordinates;
-      });
+      results = filter(results, (r) => !!r.coordinates);
     }
   }
   if (has(query, 'coordinates')) {
@@ -118,7 +106,6 @@ function filterResultsForQuery (results, query) {
         if (!r.coordinates) {
           return false;
         }
-
         const p1 = point([r.coordinates.longitude, r.coordinates.latitude]);
         const p2 = point([Number(query.coordinates.split(',')[1]), Number(query.coordinates.split(',')[0])]);
         const d = distance(p1, p2, 'kilometers') * 1000; // convert to meters
@@ -126,7 +113,6 @@ function filterResultsForQuery (results, query) {
       });
     }
   }
-
   return results;
 }
 

--- a/api/routes/locations.js
+++ b/api/routes/locations.js
@@ -9,10 +9,10 @@ import { log } from '../services/logger';
  * @apiGroup Locations
  * @apiDescription Provides a list of measurement locations and their meta data.
  *
- * @apiParam {string} [city] Limit results by a certain city.
- * @apiParam {string} [country] Limit results by a certain country.
- * @apiParam {string} [location] Limit results by a certain location.
- * @apiParam {string=pm25, pm10, so2, no2, o3, co, bc} [parameter] Limit to only a certain parameter.
+ * @apiParam {string} [city] Limit results by one or more cities (ex. `city[]=Lisboa&city[]=Porto`)
+ * @apiParam {string} [country] Limit results by one or more countries (ex. `country[]=NL&country[]=PL`)
+ * @apiParam {string} [location] Limit results by one or more locations (ex. `location[]=Reja&location[]=Nijmegen-Graafseweg`)
+ * @apiParam {string=pm25, pm10, so2, no2, o3, co, bc} [parameter] Limit certain one of more parameters (ex. `parameter[]=co&parameter[]=pm25`)
  * @apiParam {boolean} [has_geo] Filter out items that have or do not have geographic information.
  * @apiParam {string} [coordinates] Center point (`lat, lon`) used to get locations within a certain area. (ex. `coordinates=40.23,34.17`)
  * @apiParam {number} [radius=2500] Radius (in meters) used to get locations within a certain area, must be used with `coordinates`.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,6 @@
 'user strict';
 
-import { forEach, pick, has, indexOf, omit, result, find, isFinite } from 'lodash';
+import { forEach, pick, has, indexOf, isArray, omit, result, find, isFinite } from 'lodash';
 import countries from './country-list';
 
 export function payloadToKey (namespace, payload) {
@@ -214,7 +214,7 @@ export function buildSQLQuery (base, payload = {}, operators = [], betweens = []
  *
  */
 export function isGeoPayloadOK (payload) {
-  const split = payload.coordinates.split(',');
+  const split = isArray(payload.coordinates) ? payload.coordinates : payload.coordinates.split(',');
   if (split.length === 2 && split[0] !== '' && split[1] !== '' &&
     isFinite(Number(split[0])) && isFinite(Number(split[1]))) {
     if (!has(payload, 'radius') ||

--- a/test/tests.js
+++ b/test/tests.js
@@ -409,6 +409,18 @@ describe('Testing endpoints', function () {
       });
     });
 
+    it('handles multiple values', function (done) {
+      request(self.baseURL + 'locations?country=NL,PL', function (err, response, body) {
+        if (err) {
+          console.error(err);
+        }
+
+        body = JSON.parse(body);
+        expect(body.meta.found).to.equal(12);
+        done();
+      });
+    });
+
     it('handles a coordinates search', function (done) {
       request(self.baseURL + 'locations?coordinates=51.83,20.78&radius=1000', function (err, response, body) {
         if (err) {
@@ -901,12 +913,6 @@ describe('Testing endpoints', function () {
 
         payload = {
           coordinates: '40.02,',
-          radius: 10
-        };
-        expect(utils.isGeoPayloadOK(payload)).to.be.false;
-
-        payload = {
-          coordinates: '40.02',
           radius: 10
         };
         expect(utils.isGeoPayloadOK(payload)).to.be.false;

--- a/test/tests.js
+++ b/test/tests.js
@@ -439,14 +439,50 @@ describe('Testing endpoints', function () {
       });
     });
 
-    it('handles multiple values', function (done) {
-      request(self.baseURL + 'locations?country=NL,PL', function (err, response, body) {
+    it('handles multiple countries', function (done) {
+      request(self.baseURL + 'locations?country[]=NL&country[]=PL', function (err, response, body) {
         if (err) {
           console.error(err);
         }
 
         body = JSON.parse(body);
         expect(body.meta.found).to.equal(12);
+        done();
+      });
+    });
+
+    it('handles multiple parameters', function (done) {
+      request(self.baseURL + 'locations?parameter[]=co&parameter[]=pm25', function (err, response, body) {
+        if (err) {
+          console.error(err);
+        }
+
+        body = JSON.parse(body);
+        expect(body.meta.found).to.equal(49);
+        done();
+      });
+    });
+
+    it('handles multiple cities', function (done) {
+      request(self.baseURL + 'locations?city[]=Siedlce&city[]=Kolkata', function (err, response, body) {
+        if (err) {
+          console.error(err);
+        }
+
+        body = JSON.parse(body);
+        expect(body.meta.found).to.equal(2);
+        done();
+      });
+    });
+
+    it('handles multiple locations', function (done) {
+      request(self.baseURL + 'locations?location[]=Reja&location[]=Tochtermana', function (err, response, body) {
+        if (err) {
+          console.error(err);
+        }
+
+        body = JSON.parse(body);
+        expect(body.meta.found).to.equal(2);
         done();
       });
     });


### PR DESCRIPTION
Allow comma separated values to be passed on the locations endpoint for:
- city
- country
- location
- parameter

These operate as OR values.
Fix #262

If desired, we can use the same approach for other endpoints.
