### PR TITLE
Please add averagingPeriod to /latest

### DIFF
--- a/api/controllers/latest.js
+++ b/api/controllers/latest.js
@@ -65,7 +65,8 @@ function handleDataMapping (results) {
       value: r.value,
       unit: r.unit,
       date_utc: r.date_utc,
-      source_name: r.source_name
+      source_name: r.source_name,
+      averagingPeriod: r.data.averagingPeriod
     };
 
     if (r.data.coordinates) {
@@ -158,7 +159,8 @@ function groupResults (results) {
         value: m.value,
         lastUpdated: m.date_utc,
         unit: m.unit,
-        sourceName: m.source_name
+        sourceName: m.source_name,
+        averagingPeriod: m.averagingPeriod
       };
     });
     let f = {

--- a/api/routes/latest.js
+++ b/api/routes/latest.js
@@ -36,21 +36,33 @@ import { log } from '../services/logger';
  *              "value": "7.8",
  *              "lastUpdated": "2015-07-24T11:30:00.000Z",
  *              "unit": "µg/m3",
- *              "sourceName": "Punjabi Bagh"
+ *              "sourceName": "Punjabi Bagh",
+ *              "averagingPeriod": {
+ *                "unit": "hours",
+ *                "value": 0.25
+ *              }
  *             },
  *             {
  *               "parameter": "co",
  *               "value": 1.3,
  *               "lastUpdated": "2015-08-18T23:30:00.000Z",
  *               "unit": "mg/m3",
- *               "sourceName": "CPCB"
+ *               "sourceName": "CPCB",
+ *               "averagingPeriod": {
+ *                 "unit": "hours",
+ *                 "value": 0.25
+ *               }
  *             },
  *             {
  *               "parameter": "pm25",
  *               "value": 79,
  *               "lastUpdated": "2015-10-02T21:45:00.000Z",
  *               "unit": "µg/m3",
- *               "sourceName": "CPCB"
+ *               "sourceName": "CPCB",
+ *               "averagingPeriod": {
+ *                 "unit": "hours",
+ *                 "value": 0.25
+ *               }
  *             }
  *           ]
  *             ...

--- a/test/tests.js
+++ b/test/tests.js
@@ -773,6 +773,22 @@ describe('Testing endpoints', function () {
         done();
       });
     });
+
+    it('returns averaging period for a measurement', function (done) {
+      request(self.baseURL + 'latest?city=Cabauw', function (err, response, body) {
+        if (err) {
+          console.error(err);
+        }
+
+        body = JSON.parse(body);
+        body.results.forEach((r) => {
+          r.measurements.forEach((m) => {
+            expect(m.averagingPeriod).to.exist;
+          });
+        });
+        done();
+      });
+    });
   });
 
   describe('/fetches', function () {


### PR DESCRIPTION
_Edit: The original author is @mhamberg1, reason of the change [commented below](#issuecomment-316597626)._

The data format (https://github.com/openaq/openaq-data-format) includes a field called **averagingPeriod** which captures the time resolution of the measurement.

This is not currently available in /latest. Can you add this? This is important to being able to compare measurements.

Latest is here: https://api.openaq.org/v1/latest?has_geo&limit=100000
