### PR TITLE
Fix Vietnam's name

### DIFF
--- a/lib/country-list.json
+++ b/lib/country-list.json
@@ -968,7 +968,7 @@
 "Code": "VE"
 },
 {
-"Name": "Viet Nam",
+"Name": "Vietnam, Socialist Republic of",
 "Code": "VN"
 },
 {


### PR DESCRIPTION
#336 

The official name taken from Wikipedia page: https://en.wikipedia.org/wiki/Vietnam