### PR TITLE
Sort countries by name

### DIFF
--- a/api/controllers/countries.js
+++ b/api/controllers/countries.js
@@ -2,7 +2,7 @@
 
 import { prettyCountryName } from '../../lib/utils';
 import { db } from '../services/db';
-import { groupBy, uniqBy } from 'lodash';
+import { groupBy, sortBy, uniqBy } from 'lodash';
 
 import { AggregationEndpoint } from './base';
 
@@ -108,6 +108,6 @@ function groupResults (results) {
       count: count
     });
   });
-
+  final = sortBy(final, ['name']);
   return final;
 }


### PR DESCRIPTION
The countries are sorted by their ISO code right now. That makes it weird to scan the list of countries. United Kingdom in the middle of the list, etc. This fixes that, so countries are sorted by their "pretty name".