### PR TITLE
Orderby options

### DIFF
--- a/api/controllers/base.js
+++ b/api/controllers/base.js
@@ -17,13 +17,14 @@ import redis from '../services/redis';
  * @param {function} groupResults A function to group returned results
  */
 export class AggregationEndpoint {
-  constructor (cacheName, resultsQuery, activeQuery, handleDataMapping, filterResultsForQuery, groupResults) {
+  constructor (cacheName, resultsQuery, activeQuery, handleDataMapping, filterResultsForQuery, groupResults, orderResults) {
     this.cacheName = cacheName;
     this.resultsQuery = resultsQuery;
     this.handleDataMapping = handleDataMapping;
     this.filterResultsForQuery = filterResultsForQuery;
     this.groupResults = groupResults;
     this.activeQuery = activeQuery;
+    this.orderResults = orderResults;
   }
 
   /**
@@ -114,6 +115,8 @@ export class AggregationEndpoint {
 
         // Group the results to a nicer output
         results = this.groupResults(results);
+
+        results = this.orderResults(results, query);
 
         // Send back results
         sendResults(null, results);

--- a/api/controllers/base.js
+++ b/api/controllers/base.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { slice } from 'lodash';
+import { orderBy, slice } from 'lodash';
 
 import { log } from '../services/logger';
 import redis from '../services/redis';
@@ -15,16 +15,17 @@ import redis from '../services/redis';
  * @param {function} handleDataMapping A function to handle mapping db results to useful data
  * @param {function} filterResultsForQuery A function to filter returned results
  * @param {function} groupResults A function to group returned results
+ * @param {string|list} defaultOrderByProperty Default ordering field
  */
 export class AggregationEndpoint {
-  constructor (cacheName, resultsQuery, activeQuery, handleDataMapping, filterResultsForQuery, groupResults, orderResults) {
+  constructor (cacheName, resultsQuery, activeQuery, handleDataMapping, filterResultsForQuery, groupResults, defaultOrderByProperty) {
     this.cacheName = cacheName;
     this.resultsQuery = resultsQuery;
     this.handleDataMapping = handleDataMapping;
     this.filterResultsForQuery = filterResultsForQuery;
     this.groupResults = groupResults;
     this.activeQuery = activeQuery;
-    this.orderResults = orderResults;
+    this.defaultOrderByProperty = defaultOrderByProperty;
   }
 
   /**
@@ -55,6 +56,18 @@ export class AggregationEndpoint {
     .catch((err) => {
       cb(err);
     });
+  }
+
+  /**
+   * Order results after grouping them
+   *
+   * @param {array|string} results - The grouped results
+   * @param {object} query - Query object from Hapi
+   * @return {array} results - Ordered results
+   */
+  orderResults (results, query) {
+    results = orderBy(results, query.order_by || this.defaultOrderByProperty, query.sort || 'asc');
+    return results;
   }
 
   /**
@@ -91,6 +104,7 @@ export class AggregationEndpoint {
 
             // Group the results to a nicer output
             data = this.groupResults(data);
+            data = this.orderResults(data, query);
 
             // Send back results
             return sendResults(null, data);
@@ -115,7 +129,6 @@ export class AggregationEndpoint {
 
         // Group the results to a nicer output
         results = this.groupResults(results);
-
         results = this.orderResults(results, query);
 
         // Send back results

--- a/api/controllers/cities.js
+++ b/api/controllers/cities.js
@@ -15,7 +15,7 @@ let resultsQuery = db
 
 // Create the endpoint from the class, purposefully using a different cache
 // name here since we can reuse the data from the countries query
-let cities = new AggregationEndpoint('COUNTRIES', resultsQuery, null, handleDataMapping, filterResultsForQuery, groupResults);
+let cities = new AggregationEndpoint('COUNTRIES', resultsQuery, null, handleDataMapping, filterResultsForQuery, groupResults, orderResults);
 
 /**
  * Query the database and recieve back somewhat aggregated results
@@ -109,4 +109,8 @@ function groupResults (results) {
   });
 
   return final;
+}
+
+function orderResults (results, query) {
+  return results;
 }

--- a/api/controllers/cities.js
+++ b/api/controllers/cities.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { filter, has, groupBy, uniq, sortBy } from 'lodash';
+import { filter, has, groupBy, uniq } from 'lodash';
 
 import { db } from '../services/db';
 import { AggregationEndpoint } from './base';
@@ -15,7 +15,7 @@ let resultsQuery = db
 
 // Create the endpoint from the class, purposefully using a different cache
 // name here since we can reuse the data from the countries query
-let cities = new AggregationEndpoint('COUNTRIES', resultsQuery, null, handleDataMapping, filterResultsForQuery, groupResults, orderResults);
+let cities = new AggregationEndpoint('COUNTRIES', resultsQuery, null, handleDataMapping, filterResultsForQuery, groupResults, 'country');
 
 /**
  * Query the database and recieve back somewhat aggregated results
@@ -103,14 +103,5 @@ function groupResults (results) {
     });
   });
 
-  // Sort array on city name
-  final = sortBy(final, (c) => {
-    return c.city.toLowerCase();
-  });
-
   return final;
-}
-
-function orderResults (results, query) {
-  return results;
 }

--- a/api/controllers/countries.js
+++ b/api/controllers/countries.js
@@ -2,7 +2,7 @@
 
 import { prettyCountryName } from '../../lib/utils';
 import { db } from '../services/db';
-import { groupBy, sortBy, uniqBy } from 'lodash';
+import { groupBy, orderBy, uniqBy } from 'lodash';
 
 import { AggregationEndpoint } from './base';
 
@@ -18,7 +18,7 @@ const resultsQuery = db
 const activeQuery = db.select(db.raw(`* from pg_stat_activity where state = 'active' and query = '${resultsQuery.toString()}'`));
 
 // Create the endpoint from the class
-const countries = new AggregationEndpoint('COUNTRIES', resultsQuery, activeQuery, handleDataMapping, filterResultsForQuery, groupResults);
+const countries = new AggregationEndpoint('COUNTRIES', resultsQuery, activeQuery, handleDataMapping, filterResultsForQuery, groupResults, orderResults);
 
 /**
  * Query the database and recieve back somewhat aggregated results
@@ -108,6 +108,17 @@ function groupResults (results) {
       count: count
     });
   });
-  final = sortBy(final, ['name']);
   return final;
+}
+
+/**
+* Order results after grouping them
+*
+* @param {array|string} results - The grouped results
+* @param {object} query - Query object from Hapi
+* @return {array} results - Ordered results
+*/
+function orderResults (results, query) {
+  results = orderBy(results, query.order_by || 'name', query.sort);
+  return results;
 }

--- a/api/controllers/countries.js
+++ b/api/controllers/countries.js
@@ -2,7 +2,7 @@
 
 import { prettyCountryName } from '../../lib/utils';
 import { db } from '../services/db';
-import { groupBy, orderBy, uniqBy } from 'lodash';
+import { groupBy, uniqBy } from 'lodash';
 
 import { AggregationEndpoint } from './base';
 
@@ -18,7 +18,7 @@ const resultsQuery = db
 const activeQuery = db.select(db.raw(`* from pg_stat_activity where state = 'active' and query = '${resultsQuery.toString()}'`));
 
 // Create the endpoint from the class
-const countries = new AggregationEndpoint('COUNTRIES', resultsQuery, activeQuery, handleDataMapping, filterResultsForQuery, groupResults, orderResults);
+const countries = new AggregationEndpoint('COUNTRIES', resultsQuery, activeQuery, handleDataMapping, filterResultsForQuery, groupResults, 'name');
 
 /**
  * Query the database and recieve back somewhat aggregated results
@@ -109,16 +109,4 @@ function groupResults (results) {
     });
   });
   return final;
-}
-
-/**
-* Order results after grouping them
-*
-* @param {array|string} results - The grouped results
-* @param {object} query - Query object from Hapi
-* @return {array} results - Ordered results
-*/
-function orderResults (results, query) {
-  results = orderBy(results, query.order_by || 'name', query.sort);
-  return results;
 }

--- a/api/controllers/fetches.js
+++ b/api/controllers/fetches.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import { orderBy } from 'lodash';
+
 import { db } from '../services/db';
 var utils = require('../../lib/utils');
 
@@ -12,6 +14,10 @@ var utils = require('../../lib/utils');
 * @param {recordsCallback} cb - The callback that returns the records
 */
 module.exports.query = function (query, page, limit, cb) {
+  const orderByField = query.order_by;
+  delete query.order_by;
+  const sort = query.sort;
+  delete query.sort;
   // Turn the payload into something we can use with psql
   let { payload, operators, betweens, nulls, notNulls } = utils.queryFromParameters(query);
 
@@ -50,6 +56,7 @@ module.exports.query = function (query, page, limit, cb) {
         delete r.time_ended;
         return r;
       });
+      results = orderBy(results, orderByField || 'timeStarted', sort || 'asc');
       return cb(null, results, count);
     })
       .catch((err) => {

--- a/api/controllers/latest.js
+++ b/api/controllers/latest.js
@@ -16,7 +16,7 @@ const resultsQuery = db.select(db.raw('* from measurements join (select max(date
 const activeQuery = db.select(db.raw(`* from pg_stat_activity where state = 'active' and query = '${resultsQuery.toString()}'`));
 
 // Create the endpoint from the class
-const latest = new AggregationEndpoint('LATEST', resultsQuery, activeQuery, handleDataMapping, filterResultsForQuery, groupResults, orderResults);
+const latest = new AggregationEndpoint('LATEST', resultsQuery, activeQuery, handleDataMapping, filterResultsForQuery, groupResults, 'location');
 
 /**
  * Query the database and recieve back somewhat aggregated results
@@ -179,8 +179,4 @@ function groupResults (results) {
   });
 
   return final;
-}
-
-function orderResults (results, query) {
-  return results;
 }

--- a/api/controllers/latest.js
+++ b/api/controllers/latest.js
@@ -16,7 +16,7 @@ const resultsQuery = db.select(db.raw('* from measurements join (select max(date
 const activeQuery = db.select(db.raw(`* from pg_stat_activity where state = 'active' and query = '${resultsQuery.toString()}'`));
 
 // Create the endpoint from the class
-const latest = new AggregationEndpoint('LATEST', resultsQuery, activeQuery, handleDataMapping, filterResultsForQuery, groupResults);
+const latest = new AggregationEndpoint('LATEST', resultsQuery, activeQuery, handleDataMapping, filterResultsForQuery, groupResults, orderResults);
 
 /**
  * Query the database and recieve back somewhat aggregated results
@@ -179,4 +179,8 @@ function groupResults (results) {
   });
 
   return final;
+}
+
+function orderResults (results, query) {
+  return results;
 }

--- a/api/controllers/locations.js
+++ b/api/controllers/locations.js
@@ -16,7 +16,7 @@ const resultsQuery = db.select(db.raw('* from measurements join (select max(date
 const activeQuery = db.select(db.raw(`* from pg_stat_activity where state = 'active' and query = '${resultsQuery.toString()}'`));
 
 // Create the endpoint from the class
-const locations = new AggregationEndpoint('LOCATIONS', resultsQuery, activeQuery, handleDataMapping, filterResultsForQuery, groupResults);
+const locations = new AggregationEndpoint('LOCATIONS', resultsQuery, activeQuery, handleDataMapping, filterResultsForQuery, groupResults, orderResults);
 
 /**
  * Query the database and recieve back somewhat aggregated results
@@ -226,4 +226,8 @@ function groupResults (results) {
   });
 
   return final;
+}
+
+function orderResults (results, query) {
+  return results;
 }

--- a/api/controllers/locations.js
+++ b/api/controllers/locations.js
@@ -16,7 +16,7 @@ const resultsQuery = db.select(db.raw('* from measurements join (select max(date
 const activeQuery = db.select(db.raw(`* from pg_stat_activity where state = 'active' and query = '${resultsQuery.toString()}'`));
 
 // Create the endpoint from the class
-const locations = new AggregationEndpoint('LOCATIONS', resultsQuery, activeQuery, handleDataMapping, filterResultsForQuery, groupResults, orderResults);
+const locations = new AggregationEndpoint('LOCATIONS', resultsQuery, activeQuery, handleDataMapping, filterResultsForQuery, groupResults, 'location');
 
 /**
  * Query the database and recieve back somewhat aggregated results
@@ -226,8 +226,4 @@ function groupResults (results) {
   });
 
   return final;
-}
-
-function orderResults (results, query) {
-  return results;
 }

--- a/api/controllers/measurements.js
+++ b/api/controllers/measurements.js
@@ -101,29 +101,29 @@ module.exports.query = function (query, page, limit, cb) {
   }
 
   //
-  // Handle custom sorts, starting with default of most recent measurements
-  // first. Do nothing if we don't have both sort and order_by.
+  // Handle custom sorts, starting with default of most recent measurements first.
   //
   var sort = { column: 'date_utc', direction: 'desc' };
-  if (_.has(payload, 'sort') && _.has(payload, 'order_by')) {
-    // Catch case where order_by is provided as 'date'
-    if (payload.order_by === 'date') { payload.order_by = 'date_utc'; }
+  // Catch case where order_by is provided as 'date'
+  if (payload.order_by === 'date') { payload.order_by = 'date_utc'; }
 
-    // Custom sort, overwrite default
-    sort = {
-      column: payload.order_by,
-      direction: payload.sort
-    };
+  // Custom sort, overwrite default
+  sort = {
+    column: payload.order_by,
+    direction: payload.sort
+  };
 
+  if (_.has(payload, 'sort')) {
     // sanitized payload
     payload = _.omit(payload, 'sort');
-    payload = _.omit(payload, 'order_by');
-  } else if (_.has(payload, 'sort')) {
-    // sanitized payload
-    payload = _.omit(payload, 'sort');
-  } else if (_.has(payload, 'order_by')) {
+  }
+  if (_.has(payload, 'order_by')) {
     // sanitized payload
     payload = _.omit(payload, 'order_by');
+  }
+  // remove unknown sorting keywords
+  if (projection.indexOf(sort.column) === -1) {
+    sort.column = 'date_utc';
   }
 
   //

--- a/api/controllers/sources.js
+++ b/api/controllers/sources.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import { orderBy } from 'lodash';
+
 import { db } from '../services/db';
 var utils = require('../../lib/utils');
 
@@ -12,6 +14,10 @@ var utils = require('../../lib/utils');
 * @param {recordsCallback} cb - The callback that returns the records
 */
 module.exports.query = function (query, page, limit, cb) {
+  const orderByField = query.order_by;
+  delete query.order_by;
+  const sort = query.sort;
+  delete query.sort;
   // Turn the payload into something we can use with psql
   let { payload, operators, betweens, nulls, notNulls } = utils.queryFromParameters(query);
 
@@ -44,6 +50,8 @@ module.exports.query = function (query, page, limit, cb) {
       results = results.map((r) => {
         return r.data;
       });
+      results = orderBy(results, orderByField || 'name', sort || 'asc');
+
       return cb(null, results, count);
     })
       .catch((err) => {

--- a/api/routes/cities.js
+++ b/api/routes/cities.js
@@ -10,6 +10,8 @@ import { log } from '../services/logger';
  * @apiDescription Provides a simple listing of cities within the platform.
  *
  * @apiParam {string} [country] Limit results by a certain country.
+ * @apiParam {string[]} [order_by=country] Order by one or more fields (ex. `order_by=country` or `order_by[]=country&order_by[]=locations`).
+ * @apiParam {string[]} [sort=asc] Define sort order for one or more fields (ex. `sort=desc` or `sort[]=asc&sort[]=desc`).
  * @apiParam {number} [limit=100] Change the number of results returned, max is 10000.
  * @apiParam {number} [page=1] Paginate through results.
  *

--- a/api/routes/countries.js
+++ b/api/routes/countries.js
@@ -9,6 +9,8 @@ import { log } from '../services/logger';
  * @apiGroup Countries
  * @apiDescription Provides a simple listing of countries within the platform.
  *
+ * @apiParam {string[]} [order_by=name] Order by one or more fields (ex. `order_by=cities` or `order_by[]=cities&order_by[]=locations`).
+ * @apiParam {string[]} [sort=asc] Define sort order for one or more fields (ex. `sort=desc` or `sort[]=asc&sort[]=desc`).
  * @apiParam {number} [limit=100] Change the number of results returned, max is 10000.
  * @apiParam {number} [page=1] Paginate through results.
  *

--- a/api/routes/fetches.js
+++ b/api/routes/fetches.js
@@ -9,6 +9,8 @@ var m = require('../controllers/fetches.js');
  * @apiDescription Providing data about individual fetch operations that are
  * used to populate data in the platform.
  *
+ * @apiParam {string[]} [order_by=timeStarted] Order by one or more fields (ex. `order_by=timeEnded` or `order_by[]=timeEnded&order_by[]=count`).
+ * @apiParam {string[]} [sort=asc] Define sort order for one or more fields (ex. `sort=desc` or `sort[]=asc&sort[]=desc`).
  * @apiParam {number} [limit=100] Change the number of results returned, max is 10000.
  * @apiParam {number} [page=1] Paginate through results.
  *

--- a/api/routes/latest.js
+++ b/api/routes/latest.js
@@ -16,6 +16,8 @@ import { log } from '../services/logger';
  * @apiParam {boolean} [has_geo] Filter out items that have or do not have geographic information.
  * @apiParam {string} [coordinates] Center point (`lat, lon`) used to get measurements within a certain area. (ex. `coordinates=40.23,34.17`)
  * @apiParam {number} [radius=2500] Radius (in meters) used to get measurements within a certain area, must be used with `coordinates`.
+ * @apiParam {string[]} [order_by=location] Order by one or more fields (ex. `order_by=country` or `order_by[]=country&order_by[]=city`).
+ * @apiParam {string[]} [sort=asc] Define sort order for one or more fields (ex. `sort=desc` or `sort[]=asc&sort[]=desc`).
  * @apiParam {number} [limit=100] Change the number of results returned, max is 10000.
  * @apiParam {number} [page=1] Paginate through results.
  *

--- a/api/routes/locations.js
+++ b/api/routes/locations.js
@@ -17,6 +17,8 @@ import { log } from '../services/logger';
  * @apiParam {string} [coordinates] Center point (`lat, lon`) used to get locations within/near a certain area. (ex. `coordinates=40.23,34.17`)
  * @apiParam {number} [nearest] Get the X nearest locations to coordinates, must be used with `coordinates`. Wins over `radius` if both are present. Will add `distance` property to locations.
  * @apiParam {number} [radius=2500] Radius (in meters) used to get locations within a certain area, must be used with `coordinates`.
+ * @apiParam {string[]} [order_by=location] Order by one or more fields (ex. `order_by=count` or `order_by[]=country&order_by[]=count`).
+ * @apiParam {string[]} [sort=asc] Define sort order for one or more fields (ex. `sort=desc` or `sort[]=asc&sort[]=desc`).
  * @apiParam {number} [limit=100] Change the number of results returned, max is 10000.
  * @apiParam {number} [page=1] Paginate through results.
  *

--- a/api/routes/measurements.js
+++ b/api/routes/measurements.js
@@ -22,8 +22,8 @@ import { log } from '../services/logger';
  * @apiParam {number} [value_to] Show results below value threshold, useful in combination with `parameter`.
  * @apiParam {string} [date_from] Show results after a certain date. This acts on the `utc` timestamp of each measurement. (ex. `2015-12-20`, or `2015-12-20T09:00:00`)
  * @apiParam {string} [date_to] Show results before a certain date. This acts on the `utc` timestamp of each measurement. (ex. `2015-12-20`, or `2015-12-20T09:00:00`)
- * @apiParam {string} [sort=desc] The sort order, asc or desc. Must be used with `order_by`.
- * @apiParam {string} [order_by=date] Field to sort by. Must be used with `sort`.
+ * @apiParam {string[]} [order_by=date] Order by one or more fields (ex. `order_by=date` or `order_by[]=value&order_by[]=parameter`).
+ * @apiParam {string[]} [sort=asc] Define sort order for one or more fields (ex. `sort=desc` or `sort[]=asc&sort[]=desc`).
  * @apiParam {array=attribution, averagingPeriod, sourceName}  [include_fields] Include extra fields in the output in addition to default values.
  * @apiParam {number} [limit=100] Change the number of results returned, max is 10000.
  * @apiParam {number} [page=1] Paginate through results.

--- a/api/routes/parameters.js
+++ b/api/routes/parameters.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import { orderBy } from 'lodash';
+
 var p = require('../../lib/parameters.json');
 
 /**
@@ -47,6 +49,7 @@ module.exports = [
       description: 'The list of parameters that OpenAQ collects.'
     },
     handler: function (request, reply) {
+      p = orderBy(p, request.query.order_by || 'name', request.query.sort || 'asc');
       return reply(p);
     }
   }

--- a/api/routes/parameters.js
+++ b/api/routes/parameters.js
@@ -9,6 +9,9 @@ var p = require('../../lib/parameters.json');
  * @apiGroup Parameters
  * @apiDescription Provides a simple listing of parameters within the platform.
  *
+ * @apiParam {string[]} [order_by=name] Order by one or more fields (ex. `order_by=name` or `order_by[]=preferredUnit&order_by[]=id`).
+ * @apiParam {string[]} [sort=asc] Define sort order for one or more fields (ex. `sort=desc` or `sort[]=asc&sort[]=desc`).
+ *
  * @apiSuccess {string}   id            Parameter ID
  * @apiSuccess {string}   name          The parameter name
  * @apiSuccess {number}   description   A description of the parameter

--- a/api/routes/sources.js
+++ b/api/routes/sources.js
@@ -8,6 +8,8 @@ var m = require('../controllers/sources.js');
  * @apiGroup Sources
  * @apiDescription Provides a list of data sources.
  *
+ * @apiParam {string[]} [order_by=name] Order by one or more fields (ex. `order_by=country` or `order_by[]=active&order_by[]=country`).
+ * @apiParam {string[]} [sort=asc] Define sort order for one or more fields (ex. `sort=desc` or `sort[]=asc&sort[]=desc`).
  * @apiParam {number} [limit=100] Change the number of results returned, max is 10000.
  * @apiParam {number} [page=1] Paginate through results.
  *

--- a/test/data/sources.json
+++ b/test/data/sources.json
@@ -1,51 +1,53 @@
 {
-"meta": {
-"name": "openaq-api",
-"license": "CC BY 4.0",
-"website": "https://docs.openaq.org/",
-"page": 1,
-"limit": 1,
-"found": 30
-},
-"results": [
-{
-"url": "http://airquality.environment.nsw.gov.au/aquisnetnswphp/getPage.php?reportid=2",
-"adapter": "nsw",
-"name": "Australia - New South Wales",
-"city": "",
-"country": "AU",
-"description": "Measurements from the Office of Environment & Heritage of the New South Wales government.",
-"resolution": "1 hr",
-"sourceURL": "http://www.environment.nsw.gov.au/AQMS/hourlydata.htm",
-"contacts": [
-"foo@foo.com"
-]
-},
-{
-"url": "http://airquality.environment.nsw.gov.au/aquisnetnswphp/getPage.php?reportid=2",
-"adapter": "nsw",
-"name": "Australia - New South Wales",
-"city": "",
-"country": "AU",
-"description": "Measurements from the Office of Environment & Heritage of the New South Wales government.",
-"resolution": "1 hr",
-"sourceURL": "http://www.environment.nsw.gov.au/AQMS/hourlydata.htm",
-"contacts": [
-"foo@foo.com"
-]
-},
-{
-"url": "http://airquality.environment.nsw.gov.au/aquisnetnswphp/getPage.php?reportid=2",
-"adapter": "nsw",
-"name": "Australia - New South Wales",
-"city": "",
-"country": "AU",
-"description": "Measurements from the Office of Environment & Heritage of the New South Wales government.",
-"resolution": "1 hr",
-"sourceURL": "http://www.environment.nsw.gov.au/AQMS/hourlydata.htm",
-"contacts": [
-"foo@foo.com"
-]
-}
-]
+    "meta": {
+        "name": "openaq-api",
+        "license": "CC BY 4.0",
+        "website": "https://docs.openaq.org/",
+        "page": 1,
+        "limit": 3,
+        "found": 69
+    },
+    "results": [
+        {
+            "url": null,
+            "adapter": "eea",
+            "name": "EEA Andora",
+            "city": "",
+            "country": "AD",
+            "description": "Andoran data from UTD service",
+            "sourceURL": "http://www.eea.europa.eu/themes/air/air-quality",
+            "contacts": [
+                "olaf.veerman@gmail.com",
+                "info@openaq.org"
+            ],
+            "active": false
+        },
+        {
+            "url": "http://www.buenosaires.gob.ar/areas/med_ambiente/apra/calidad_amb/red_monitoreo/index.php?",
+            "adapter": "buenos-aires",
+            "name": "Buenos Aires",
+            "country": "AR",
+            "city": "Buenos Aires",
+            "description": "Air quality data for Buenos Aires",
+            "sourceURL": "http://www.buenosaires.gob.ar/agenciaambiental",
+            "contacts": [
+                "info@openaq.org"
+            ],
+            "active": true
+        },
+        {
+            "url": null,
+            "adapter": "eea",
+            "name": "EEA Austria",
+            "city": "",
+            "country": "AT",
+            "description": "Austrian data from UTD service",
+            "sourceURL": "http://www.eea.europa.eu/themes/air/air-quality",
+            "contacts": [
+                "olaf.veerman@gmail.com",
+                "info@openaq.org"
+            ],
+            "active": false
+        }
+    ]
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -163,6 +163,17 @@ describe('Testing endpoints', function () {
         done();
       });
     });
+
+    it('should not complain about wrong order query', (done) => {
+      request(`${self.baseURL}countries?order_by=non-existing-field`, (err, response, body) => {
+        if (err) {
+          console.error(err);
+        }
+
+        expect(response.statusCode).to.equal(200);
+        done();
+      });
+    });
   });
 
   describe('/parameters', function () {
@@ -549,6 +560,58 @@ describe('Testing endpoints', function () {
 
         var res = JSON.parse(body);
         expect(res.meta.found).to.equal(32);
+        done();
+      });
+    });
+
+    it('can be ordered', function (done) {
+      request(`${self.baseURL}measurements?order_by=value&sort=desc`, (err, response, body) => {
+        if (err) {
+          console.error(err);
+        }
+
+        var res = JSON.parse(body);
+        expect(res.results[0].value).to.be.above(res.results[1].value);
+        expect(res.results[0].value).to.be.above(res.results[res.results.length-1].value);
+        expect(res.results).to.deep.equal(orderBy(res.results, 'value', 'desc'));
+        done();
+      });
+    });
+
+    it('can be ordered with multiple fields and directions', function (done) {
+      request(`${self.baseURL}measurements?order_by[]=country&order_by[]=sourceName&sort[]=desc&sort=[]=desc`, (err, response, body) => {
+        if (err) {
+          console.error(err);
+        }
+
+        var res = JSON.parse(body);
+        expect(res.results[0].value).to.be.below(res.results[1].value);
+        expect(res.results).to.equal(orderBy(res.results, ['country', 'sourceName'], ['desc', 'desc']));
+        done();
+      });
+    });
+
+    it('should not require sorting direction when ordering', function (done) {
+      request(`${self.baseURL}measurements?order_by=value`, (err, response, body) => {
+        if (err) {
+          console.error(err);
+        }
+
+        var res = JSON.parse(body);
+        expect(res.results[0].value).to.be.below(res.results[1].value);
+        expect(res.results[0].value).to.be.below(res.results[res.results.length-1].value);
+        expect(res.results).to.equal(orderBy(res.results, 'value'));
+        done();
+      });
+    });
+
+    it('should not complain about wrong order query', (done) => {
+      request(`${self.baseURL}measurements?order_by=non-existing-field&sort=asc`, (err, response, body) => {
+        if (err) {
+          console.error(err);
+        }
+
+        expect(response.statusCode).to.equal(200);
         done();
       });
     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -8,6 +8,7 @@ var Server = require('../api/services/server');
 var testPort = 2000;
 var request = require('request');
 var utils = require('../lib/utils');
+import { orderBy } from 'lodash';
 
 describe('Testing endpoints', function () {
   var self = this;
@@ -138,6 +139,31 @@ describe('Testing endpoints', function () {
         done();
       });
     });
+
+    it('can be ordered', (done) => {
+      request(`${self.baseURL}countries?order_by=count&sort=asc`, (err, response, body) => {
+        if (err) {
+          console.error(err);
+        }
+
+        const res = JSON.parse(body);
+        expect(res.results).to.deep.equal(orderBy(res.results, 'count', 'asc'));
+        done();
+      });
+    });
+
+    it('can be ordered by multiple fields and directions', (done) => {
+      request(`${self.baseURL}countries?order_by[]=cities&order_by[]=locations&sort[]=asc&sort[]=desc]`, (err, response, body) => {
+        if (err) {
+          console.error(err);
+        }
+
+        const res = JSON.parse(body);
+        expect(res.results).to.deep.equal(orderBy(res.results, ['cities', 'locations'], ['asc', 'desc']));
+        done();
+      });
+    });
+    
   });
 
   describe('/parameters', function () {

--- a/test/tests.js
+++ b/test/tests.js
@@ -163,7 +163,6 @@ describe('Testing endpoints', function () {
         done();
       });
     });
-    
   });
 
   describe('/parameters', function () {

--- a/test/tests.js
+++ b/test/tests.js
@@ -572,21 +572,20 @@ describe('Testing endpoints', function () {
 
         var res = JSON.parse(body);
         expect(res.results[0].value).to.be.above(res.results[1].value);
-        expect(res.results[0].value).to.be.above(res.results[res.results.length-1].value);
+        expect(res.results[0].value).to.be.above(res.results[res.results.length - 1].value);
         expect(res.results).to.deep.equal(orderBy(res.results, 'value', 'desc'));
         done();
       });
     });
 
     it('can be ordered with multiple fields and directions', function (done) {
-      request(`${self.baseURL}measurements?order_by[]=country&order_by[]=sourceName&sort[]=desc&sort=[]=desc`, (err, response, body) => {
+      request(`${self.baseURL}measurements?order_by[]=country&order_by[]=sourceName&sort[]=desc&sort[]=desc`, (err, response, body) => {
         if (err) {
           console.error(err);
         }
 
         var res = JSON.parse(body);
-        expect(res.results[0].value).to.be.below(res.results[1].value);
-        expect(res.results).to.equal(orderBy(res.results, ['country', 'sourceName'], ['desc', 'desc']));
+        expect(res.results).to.deep.equal(orderBy(res.results, ['country', 'sourceName'], ['desc', 'desc']));
         done();
       });
     });
@@ -599,7 +598,7 @@ describe('Testing endpoints', function () {
 
         var res = JSON.parse(body);
         expect(res.results[0].value).to.be.below(res.results[1].value);
-        expect(res.results[0].value).to.be.below(res.results[res.results.length-1].value);
+        expect(res.results[0].value).to.be.below(res.results[res.results.length - 1].value);
         expect(res.results).to.deep.equal(orderBy(res.results, 'value'));
         done();
       });

--- a/test/tests.js
+++ b/test/tests.js
@@ -192,6 +192,30 @@ describe('Testing endpoints', function () {
         done();
       });
     });
+
+    it('can be ordered', (done) => {
+      request(`${self.baseURL}parameters?order_by=preferredUnit`, (err, response, body) => {
+        if (err) {
+          console.error(err);
+        }
+
+        const res = JSON.parse(body);
+        expect(res.results).to.deep.equal(orderBy(res.results, 'preferredUnit'));
+        done();
+      });
+    });
+
+    it('can be ordered by multiple fields and directions', (done) => {
+      request(`${self.baseURL}parameters?order_by[]=id&order_by[]=name&sort[]=asc&sort[]=desc]`, (err, response, body) => {
+        if (err) {
+          console.error(err);
+        }
+
+        const res = JSON.parse(body);
+        expect(res.results).to.deep.equal(orderBy(res.results, ['id', 'name'], ['asc', 'desc']));
+        done();
+      });
+    });
   });
 
   describe('/upload', function () {
@@ -279,6 +303,18 @@ describe('Testing endpoints', function () {
         var res = JSON.parse(body);
         expect(res.meta.limit).to.deep.equal(1);
         expect(res.results.length).to.equal(1);
+        done();
+      });
+    });
+
+    it('can be ordered', (done) => {
+      request(`${self.baseURL}cities?order_by=country&sort=desc`, (err, response, body) => {
+        if (err) {
+          console.error(err);
+        }
+
+        const res = JSON.parse(body);
+        expect(res.results).to.deep.equal(orderBy(res.results, 'country', 'desc'));
         done();
       });
     });
@@ -697,6 +733,30 @@ describe('Testing endpoints', function () {
         done();
       });
     });
+
+    it('can be ordered', (done) => {
+      request(`${self.baseURL}locations?order_by=count&sort=desc`, (err, response, body) => {
+        if (err) {
+          console.error(err);
+        }
+
+        const res = JSON.parse(body);
+        expect(res.results).to.deep.equal(orderBy(res.results, 'count', 'desc'));
+        done();
+      });
+    });
+
+    it('can be ordered by multiple fields and directions', (done) => {
+      request(`${self.baseURL}parameters?order_by[]=lastUpdated&order_by[]=country&sort[]=desc&sort[]=asc]`, (err, response, body) => {
+        if (err) {
+          console.error(err);
+        }
+
+        const res = JSON.parse(body);
+        expect(res.results).to.deep.equal(orderBy(res.results, ['lastUpdated', 'country'], ['desc', 'asc']));
+        done();
+      });
+    });
   });
 
   describe('/latest', function () {
@@ -814,6 +874,30 @@ describe('Testing endpoints', function () {
         done();
       });
     });
+
+    it('can be ordered', (done) => {
+      request(`${self.baseURL}latest?order_by=city`, (err, response, body) => {
+        if (err) {
+          console.error(err);
+        }
+
+        const res = JSON.parse(body);
+        expect(res.results).to.deep.equal(orderBy(res.results, 'city'));
+        done();
+      });
+    });
+
+    it('can be ordered by multiple fields and directions', (done) => {
+      request(`${self.baseURL}parameters?order_by[]=country&order_by[]=city&sort[]=desc&sort[]=asc]`, (err, response, body) => {
+        if (err) {
+          console.error(err);
+        }
+
+        const res = JSON.parse(body);
+        expect(res.results).to.deep.equal(orderBy(res.results, ['country', 'city'], ['desc', 'asc']));
+        done();
+      });
+    });
   });
 
   describe('/fetches', function () {
@@ -872,6 +956,30 @@ describe('Testing endpoints', function () {
         done();
       });
     });
+
+    it('can be ordered', (done) => {
+      request(`${self.baseURL}fetches?order_by=timeEnded&sort=desc`, (err, response, body) => {
+        if (err) {
+          console.error(err);
+        }
+
+        const res = JSON.parse(body);
+        expect(res.results).to.deep.equal(orderBy(res.results, 'timeEnded', 'desc'));
+        done();
+      });
+    });
+
+    it('can be ordered by multiple fields and directions', (done) => {
+      request(`${self.baseURL}fetches?order_by[]=timeStarted&order_by[]=count&sort[]=desc&sort[]=desc]`, (err, response, body) => {
+        if (err) {
+          console.error(err);
+        }
+
+        const res = JSON.parse(body);
+        expect(res.results).to.deep.equal(orderBy(res.results, ['timeStarted', 'count'], ['desc', 'desc']));
+        done();
+      });
+    });
   });
 
   describe('/sources', function () {
@@ -916,6 +1024,56 @@ describe('Testing endpoints', function () {
         var res = JSON.parse(body);
         expect(res.meta.limit).to.equal(1);
         expect(res.results.length).to.equal(1);
+        done();
+      });
+    });
+
+    it('can be ordered', (done) => {
+      request(`${self.baseURL}sources?order_by=country`, (err, response, body) => {
+        if (err) {
+          console.error(err);
+        }
+
+        const res = JSON.parse(body);
+        expect(res.results).to.deep.equal(orderBy(res.results, 'country'));
+        done();
+      });
+    });
+
+    it('can be ordered by multiple fields and directions', (done) => {
+      request(`${self.baseURL}sources?order_by[]=adapter&order_by[]=country&sort[]=asc&sort[]=asc]`, (err, response, body) => {
+        if (err) {
+          console.error(err);
+        }
+
+        const res = JSON.parse(body);
+        expect(res.results).to.deep.equal(orderBy(res.results, ['adapter', 'country'], ['asc', 'asc']));
+        done();
+      });
+    });
+
+    it('can be ordered by boolean field, false first', (done) => {
+      request(`${self.baseURL}sources?order_by=active&sort=asc`, (err, response, body) => {
+        if (err) {
+          console.error(err);
+        }
+
+        const res = JSON.parse(body);
+        expect(res.results).to.deep.equal(orderBy(res.results, 'active', 'asc'));
+        expect(res.results[0].active).to.equal(false);
+        done();
+      });
+    });
+
+    it('can be ordered by boolean field, true first', (done) => {
+      request(`${self.baseURL}sources?order_by=active&sort=desc`, (err, response, body) => {
+        if (err) {
+          console.error(err);
+        }
+
+        const res = JSON.parse(body);
+        expect(res.results).to.deep.equal(orderBy(res.results, 'active', 'desc'));
+        expect(res.results[0].active).to.equal(true);
         done();
       });
     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -600,7 +600,7 @@ describe('Testing endpoints', function () {
         var res = JSON.parse(body);
         expect(res.results[0].value).to.be.below(res.results[1].value);
         expect(res.results[0].value).to.be.below(res.results[res.results.length-1].value);
-        expect(res.results).to.equal(orderBy(res.results, 'value'));
+        expect(res.results).to.deep.equal(orderBy(res.results, 'value'));
         done();
       });
     });


### PR DESCRIPTION
@jflasher This is a demo for the order_by option. It basically piggybacks the AggregationEndpoint by adding a function for ordering. It's called after the final groupResults. Endpoints that aren't using AggregationEndpoint will need a bit different way.

Let me know what you think, and I'll add the option for the other endpoints.

- [x] Add docs
- [x] Add tests
- [x] Fix measurements sorting

When complete, this fixes #207.