### PR TITLE
Few npm helper commands for convenience

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
   "main": "",
   "scripts": {
     "lint": "eslint .",
-    "test": "npm run lint && mocha test/** --require babel-register",
+    "test-only": "mocha test/** --require babel-register",
+    "test": "npm run lint && npm run test-only",
     "local-test": "PSQL_DATABASE=openaq-test npm test",
+    "local-test-only": "PSQL_DATABASE=openaq-test npm run test-only",
     "start": "node index.js",
     "docs": "apidoc -i api/ -o docs/",
     "docker": "docker-compose -p openaq run --rm --service-ports api",


### PR DESCRIPTION
Some helper commands for local development.

Reason for `test-only` commands: For me, I fix stuff first, and only lint before commit. It's annoying for me to look for lines to lint while running tests, etc.