### PR TITLE
Latest distance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - In Latest endpoint, `distance` response field is added
   when `coordinates` filter is used.
+### Deprecated
+- In Locations endpoint, instead of the `nearest` option,
+  use `order_by=distance` along with `limit`.
 
 ## [1.1.0] - 2017-08-12
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- In Latest endpoint, `distance` response field is added
+  when `coordinates` filter is used.
 
 ## [1.1.0] - 2017-08-12
 ### Added

--- a/api/controllers/latest.js
+++ b/api/controllers/latest.js
@@ -127,15 +127,16 @@ function filterResultsForQuery (results, query) {
       if (has(query, 'radius')) {
         radius = query.radius;
       }
-      results = filter(results, (r, i) => {
-        if (!r.coordinates) {
-          return false;
-        }
-
+      results = filter(results, 'coordinates');
+      results = results.map((r, i) => {
         const p1 = point([r.coordinates.longitude, r.coordinates.latitude]);
         const p2 = point([Number(query.coordinates.split(',')[1]), Number(query.coordinates.split(',')[0])]);
         const d = distance(p1, p2, 'kilometers') * 1000; // convert to meters
-        return d <= radius;
+        r.distance = d;
+        return r;
+      });
+      results = filter(results, (r, i) => {
+        return r.distance <= radius;
       });
     }
   }
@@ -167,6 +168,7 @@ function groupResults (results) {
       location: m[0].location,
       city: m[0].city,
       country: m[0].country,
+      distance: m[0].distance,
       measurements: measurements
     };
 

--- a/api/routes/latest.js
+++ b/api/routes/latest.js
@@ -14,7 +14,7 @@ import { log } from '../services/logger';
  * @apiParam {string} [location] Limit results by a certain location.
  * @apiParam {string=pm25, pm10, so2, no2, o3, co, bc} [parameter] Limit to only a certain parameter.
  * @apiParam {boolean} [has_geo] Filter out items that have or do not have geographic information.
- * @apiParam {string} [coordinates] Center point (`lat, lon`) used to get measurements within a certain area. (ex. `coordinates=40.23,34.17`)
+ * @apiParam {string} [coordinates] Center point (`lat, lon`) used to get measurements within a certain area. (ex. `coordinates=40.23,34.17`) Will add `distance` property.
  * @apiParam {number} [radius=2500] Radius (in meters) used to get measurements within a certain area, must be used with `coordinates`.
  * @apiParam {number} [limit=100] Change the number of results returned, max is 10000.
  * @apiParam {number} [page=1] Paginate through results.

--- a/api/routes/locations.js
+++ b/api/routes/locations.js
@@ -15,7 +15,7 @@ import { log } from '../services/logger';
  * @apiParam {string=pm25, pm10, so2, no2, o3, co, bc} [parameter] Limit to certain one or more parameters (ex. `parameter=pm25` or `parameter[]=co&parameter[]=pm25`)
  * @apiParam {boolean} [has_geo] Filter out items that have or do not have geographic information.
  * @apiParam {string} [coordinates] Center point (`lat, lon`) used to get locations within/near a certain area. (ex. `coordinates=40.23,34.17`)
- * @apiParam {number} [nearest] Get the X nearest locations to coordinates, must be used with `coordinates`. Wins over `radius` if both are present. Will add `distance` property to locations.
+ * @apiParam {number} [nearest] Get the X nearest locations to coordinates, must be used with `coordinates`. Wins over `radius` if both are present. Will add `distance` property to locations. DEPRECATED: Use `order_by=distance` with `limit=X` instead.
  * @apiParam {number} [radius=2500] Radius (in meters) used to get locations within a certain area, must be used with `coordinates`.
  * @apiParam {string[]} [order_by=location] Order by one or more fields (ex. `order_by=count` or `order_by[]=country&order_by[]=count`).
  * @apiParam {string[]} [sort=asc] Define sort order for one or more fields (ex. `sort=desc` or `sort[]=asc&sort[]=desc`).

--- a/test/tests.js
+++ b/test/tests.js
@@ -891,6 +891,17 @@ describe('Testing endpoints', function () {
       });
     });
 
+    it('includes distance on coordinates search', function (done) {
+      request(`${self.baseURL}latest?coordinates=51.83,20.78`, function (err, response, body) {
+        if (err) {
+          console.error(err);
+        }
+        body = JSON.parse(body);
+        expect(body.results[0]).to.have.property('distance');
+        done();
+      });
+    });
+
     // https://github.com/openaq/openaq-api/issues/232
     it('handles has_geo searches', function (done) {
       request(self.baseURL + 'latest?has_geo', function (err, response, body) {


### PR DESCRIPTION
Resolves #310 

This adds `distance` response field when `coordinates` filter is used.

On not doing `nearest` for `latest` (from #310 comment):

Now that we have sorting on arbitrary fields, I think `limit` and order by `distance` could replace the `nearest` option. The matching query would look like:

```
/api/v1/latest?coordinates=x,y&radius=z&order_by=distance&limit=10
```

I propose to skip the `nearest` parameter, and just add `distance` in the response field. Could go as far as to deprecate the `nearest` on `locations`.

- [x] Add to changelog
- [x] Add test
