### PR TITLE
Don't pass detailed measurement on fetch

### DIFF
--- a/api/controllers/fetches.js
+++ b/api/controllers/fetches.js
@@ -54,6 +54,8 @@ module.exports.query = function (query, page, limit, cb) {
         delete r.time_started;
         r.timeEnded = r.time_ended;
         delete r.time_ended;
+        // ensure that detailed measurements are not returned
+        if (r.results) { delete r.results };
         return r;
       });
       results = orderBy(results, orderByField || 'timeStarted', sort || 'asc');

--- a/api/controllers/fetches.js
+++ b/api/controllers/fetches.js
@@ -54,8 +54,11 @@ module.exports.query = function (query, page, limit, cb) {
         delete r.time_started;
         r.timeEnded = r.time_ended;
         delete r.time_ended;
-        // ensure that detailed measurements are not returned
-        if (r.results) { delete r.results };
+        // TMP - ensure that detailed measurements are not returned
+        // can be removed after fix for #351 is implemented in openaq-fetch
+        if (r.results) {
+          delete r.results;
+        }
         return r;
       });
       results = orderBy(results, orderByField || 'timeStarted', sort || 'asc');

--- a/api/controllers/fetches.js
+++ b/api/controllers/fetches.js
@@ -56,8 +56,10 @@ module.exports.query = function (query, page, limit, cb) {
         delete r.time_ended;
         // TMP - ensure that detailed measurements are not returned
         // can be removed after fix for #351 is implemented in openaq-fetch
-        if (r.results) {
-          delete r.results;
+        for (let key in r.results) {
+          if (r.results[key] && r.results[key]['results']) {
+            delete r.results[key].results;
+          }
         }
         return r;
       });


### PR DESCRIPTION
The database shouldn't contain this in the first place, just a safe-guard.

@kamicut Ready to be tested.