### PR TITLE
Fix knex pool values types

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1,1 +1,12 @@
-{}
+{
+  "knex": {
+    "client": "pg",
+    "pool": {
+      "min": 2,
+      "max": 10
+    },
+    "migrations": {
+      "tableName": "migrations"
+    }
+  }
+}

--- a/config/development.json
+++ b/config/development.json
@@ -1,19 +1,11 @@
 {
   "knex": {
-    "client": "pg",
     "connection": {
       "host": "localhost",
       "user": "docker",
       "port": "15432",
       "password": "docker",
       "database": "gis"
-    },
-    "pool": {
-      "min": 2,
-      "max": 10
-    },
-    "migrations": {
-      "tableName": "migrations"
     }
   }
 }

--- a/config/test.json
+++ b/config/test.json
@@ -1,19 +1,11 @@
 {
   "knex": {
-    "client": "pg",
     "connection": {
       "host": "localhost",
       "user": "docker",
       "port": "25432",
       "password": "docker",
       "database": "gis"
-    },
-    "pool": {
-      "min": 2,
-      "max": 10
-    },
-    "migrations": {
-      "tableName": "migrations"
     }
   }
 }

--- a/config/travis.json
+++ b/config/travis.json
@@ -1,19 +1,11 @@
 {
   "knex": {
-    "client": "pg",
     "connection": {
       "host": "localhost",
       "user": "docker",
       "port": "5432",
       "password": "docker",
       "database": "gis"
-    },
-    "pool": {
-      "min": 2,
-      "max": 10
-    },
-    "migrations": {
-      "tableName": "migrations"
     }
   }
 }

--- a/knexfile.js
+++ b/knexfile.js
@@ -14,4 +14,4 @@ if (knexConfig.pool) {
   }
 }
 
-module.exports = knexConfig;
+module.exports = Object.freeze(knexConfig);

--- a/knexfile.js
+++ b/knexfile.js
@@ -1,3 +1,17 @@
 require('babel-register');
 const config = require('config');
-module.exports = config.get('knex');
+
+// Get a mutable object from config
+const knexConfig = JSON.parse(JSON.stringify(config.get('knex')));
+
+// Fix pool min/max types when using environment variables
+if (knexConfig.pool) {
+  if (typeof knexConfig.pool.min !== 'undefined') {
+    knexConfig.pool.min = parseInt(knexConfig.pool.min);
+  }
+  if (typeof knexConfig.pool.max !== 'undefined') {
+    knexConfig.pool.max = parseInt(knexConfig.pool.max);
+  }
+}
+
+module.exports = knexConfig;


### PR DESCRIPTION
Changed the knexfile so it always parses the pool values as integer. Now it should allow the use of `PSQL_POOL_MIN` and `PSQL_POOL_MAX` environment variables.

@jflasher Looking at the previous implementation an error would also be thrown if the environment variables to configure pool size were used, because they weren't parsed as int:

https://github.com/openaq/openaq-api/blob/master/knexfile.js#L9-L12

