### PR TITLE
Remove parameter `nearest` from docs

### DIFF
--- a/api/routes/locations.js
+++ b/api/routes/locations.js
@@ -21,7 +21,6 @@ const orderableColumns = ['city', 'country', 'location', 'distance', 'count'];
  * @apiParam {string=pm25, pm10, so2, no2, o3, co, bc} [parameter] Limit to certain one or more parameters (ex. `parameter=pm25` or `parameter[]=co&parameter[]=pm25`)
  * @apiParam {boolean} [has_geo] Filter out items that have or do not have geographic information.
  * @apiParam {string} [coordinates] Center point (`lat, lon`) used to get locations within/near a certain area. (ex. `coordinates=40.23,34.17`). Must be used with `order_by=distance` or `radius=2500`, otherwise won't affect query.
- * @apiParam {number} [nearest] DEPRECATED: Use `order_by=distance` with `limit=X` instead.
  * @apiParam {number} [radius=2500] Radius (in meters) used to get locations within a certain area, must be used with `coordinates`.
  * @apiParam {string[]} [order_by=location] Order by one or more fields (ex. `order_by=count` or `order_by[]=country&order_by[]=count`).
  * @apiParam {string[]} [sort=asc] Define sort order for one or more fields (ex. `sort=desc` or `sort[]=asc&sort[]=desc`).
@@ -32,7 +31,7 @@ const orderableColumns = ['city', 'country', 'location', 'distance', 'count'];
  * @apiSuccess {string}   country       Country containing location in 2 letter ISO code
  * @apiSuccess {string}   city          City containing location
  * @apiSuccess {number}   count         Number of measurements, cumulative by specificity level
- * @apiSuccess {number}   distance      Distance to the specified coordinates (present when `nearest` and `coordinates` parameters are used, measured by meters)
+ * @apiSuccess {number}   distance      Distance to the specified coordinates (available when `coordinates` parameter is used, measured by meters)
  * @apiSuccess {string}   sourceName    Can follow this to determine active adapter used for this location
  * @apiSuccess {array}    sourceNames   Array of sourceName, both active and unused ones
  * @apiSuccess {date}     firstUpdated  When was data first grabbed for this location (in UTC)?


### PR DESCRIPTION
Support for parameter `nearest` on `/locations` endpoint was dropped. This updates the API documentation.