### PR TITLE
Trigger Athena update with action "DATABASE_UPDATED" at /webhooks

### DIFF
--- a/api/controllers/webhooks.js
+++ b/api/controllers/webhooks.js
@@ -28,10 +28,8 @@ module.exports.handleAction = function (payload, cb) {
   }
 
   switch (payload.action) {
-    case 'ATHENA_SYNC':
-      startAthenaSyncTask();
-      break;
     case 'DATABASE_UPDATED':
+      startAthenaSyncTask();
       if (redis && redis.ready) {
         // Rebuild cache instead of waiting for first query
         runCachedQueries(redis);


### PR DESCRIPTION
The webhook to fetch data from Athena had a specific action `ATHENA_UPDATE`. This PR removes this action and move the athena task to action `DATABASE_UPDATED`, which already existed and currently only trigger a Redis cache update.

See: https://github.com/openaq/openaq-api/issues/398