### PR TITLE
Add completeness check

### DIFF
--- a/api/routes/locations-metadata.js
+++ b/api/routes/locations-metadata.js
@@ -2,9 +2,10 @@
 import Boom from 'boom';
 import config from 'config';
 import _ from 'lodash';
+import util from 'util';
 
 import { db } from '../services/db';
-import metadataSchema from '../../lib/location-metadata-schema';
+import metadataSchema, { computeCompleteness } from '../../lib/location-metadata-schema';
 
 const { strategy: authStrategy } = config.get('auth');
 
@@ -29,7 +30,7 @@ module.exports = [
     path: '/v1/locations/{id}/metadata',
     config: {
       description: 'Updates the metadata associated with a given location',
-      auth: authStrategy,
+      // auth: authStrategy,
       validate: {
         payload: metadataSchema
       }
@@ -40,6 +41,8 @@ module.exports = [
         if (!(await checkLocation(request.params.id))) {
           return reply(Boom.notFound('This location does not exist'));
         }
+
+        console.log('Completeness', computeCompleteness(request.payload) * 100);
 
         const user = _.get(request, 'auth.credentials.sub', 'anonymous');
 

--- a/api/routes/locations-metadata.js
+++ b/api/routes/locations-metadata.js
@@ -42,8 +42,6 @@ module.exports = [
           return reply(Boom.notFound('This location does not exist'));
         }
 
-        console.log('Completeness', computeCompleteness(request.payload) * 100);
-
         const user = _.get(request, 'auth.credentials.sub', 'anonymous');
 
         const res = await db.transaction(async trx => {
@@ -52,7 +50,8 @@ module.exports = [
             .insert({
               userId: user,
               locationId: request.params.id,
-              data: request.payload
+              data: request.payload,
+              completeness: computeCompleteness(request.payload)
             });
 
           // Get result after insertion.

--- a/api/routes/locations-metadata.js
+++ b/api/routes/locations-metadata.js
@@ -2,7 +2,6 @@
 import Boom from 'boom';
 import config from 'config';
 import _ from 'lodash';
-import util from 'util';
 
 import { db } from '../services/db';
 import metadataSchema, { computeCompleteness } from '../../lib/location-metadata-schema';

--- a/api/routes/locations-metadata.js
+++ b/api/routes/locations-metadata.js
@@ -29,7 +29,7 @@ module.exports = [
     path: '/v1/locations/{id}/metadata',
     config: {
       description: 'Updates the metadata associated with a given location',
-      // auth: authStrategy,
+      auth: authStrategy,
       validate: {
         payload: metadataSchema
       }

--- a/api/routes/locations.js
+++ b/api/routes/locations.js
@@ -136,7 +136,8 @@ module.exports = [
           ],
           metadata: Joi.boolean(),
           siteType: [Joi.string(), Joi.array().items(Joi.string())],
-          activationDate: Joi.array().items(Joi.date()).length(2)
+          activationDate: Joi.array().items(Joi.date()).length(2),
+          completeness: Joi.array().items(Joi.number()).length(2)
         }
       }
     },
@@ -214,7 +215,13 @@ module.exports = [
           .modify(query => {
             // If the metadata flag was passed, join the data.
             if (metadata) {
-              query.select('latest_locations_metadata.data as metadata');
+              query.select(
+                'latest_locations_metadata.data as metadata',
+                'latest_locations_metadata.version as metadataVersion',
+                'latest_locations_metadata.userId as metadataUserId',
+                'latest_locations_metadata.updatedAt as metadataUpdatedAt',
+                'latest_locations_metadata.completeness as metadataCompleteness'
+              );
             }
           })
           .offset(offset)
@@ -312,7 +319,8 @@ module.exports = [
                   'latest_locations_metadata.data as metadata',
                   'latest_locations_metadata.version as metadataVersion',
                   'latest_locations_metadata.userId as metadataUserId',
-                  'latest_locations_metadata.updatedAt as metadataUpdatedAt'
+                  'latest_locations_metadata.updatedAt as metadataUpdatedAt',
+                  'latest_locations_metadata.completeness as metadataCompleteness'
                 );
             }
           })

--- a/lib/location-metadata-schema.js
+++ b/lib/location-metadata-schema.js
@@ -63,6 +63,11 @@ export default schema;
 
 /**
  * Computes the percentage of completeness based on the schema properties.
+ * The number of properties needed in order for the metadata to be considered
+ * complete depends on the number of children the array items have.
+ * By default he minimum number assmes that each array has 1 child. However,
+ * as soon as more children are added the number increased by at least the
+ * number of props in `instrumentsSimpleChecks`.
  *
  * @param {object} metadata Location metadata payload
  */

--- a/lib/location-metadata-schema.js
+++ b/lib/location-metadata-schema.js
@@ -1,4 +1,5 @@
 import Joi from 'joi';
+import _ from 'lodash';
 
 const attributionSchema = {
   name: Joi.string().description('Attribution Name'),
@@ -60,8 +61,11 @@ const schema = {
 
 export default schema;
 
-import _ from 'lodash';
-
+/**
+ * Computes the percentage of completeness based on the schema properties.
+ *
+ * @param {object} metadata Location metadata payload
+ */
 export function computeCompleteness (metadata) {
   const checkProp = (prop, obj = metadata) => {
     const v = _.get(obj, prop);

--- a/lib/location-metadata-schema.js
+++ b/lib/location-metadata-schema.js
@@ -59,3 +59,85 @@ const schema = {
 };
 
 export default schema;
+
+import _ from 'lodash';
+
+export function computeCompleteness (metadata) {
+  const checkProp = (prop, obj = metadata) => {
+    const v = _.get(obj, prop);
+    return Number(v !== undefined && v !== null);
+  };
+
+  const simpleRootChecks = [
+    'name',
+    'siteType',
+    'sourceType',
+    'elevation',
+    'activationDate',
+    'active',
+    'coordinates.latitude',
+    'coordinates.longitude'
+  ];
+
+  let requiredPropCount = simpleRootChecks.length;
+  let actualPropCount = simpleRootChecks.reduce((c, prop) => c + checkProp(prop), 0);
+
+  // If is not active we need the deativation date.
+  if (metadata.active === false) {
+    requiredPropCount++;
+    actualPropCount += checkProp('deactivationDate');
+  }
+
+  // The attribution is required, but the amount of props depends on the amount
+  // of children.
+  const attr = metadata.attribution || [];
+  requiredPropCount += Math.max(2, attr.length * 2);
+  actualPropCount += attr.reduce((total, child) => {
+    return total + [
+      'name',
+      'url'
+    ].reduce((c, prop) => c + checkProp(prop, child), 0);
+  }, 0);
+
+  // Calc instrument props.
+  const inst = metadata.instruments || [];
+  const instrumentsSimpleChecks = [
+    'type',
+    'serialNumber',
+    'manufacturer',
+    'modelName',
+    'measurementStyle',
+    'rawFrequency',
+    'reportingFrequency',
+    'calibrationProcedures',
+    'inletHeight',
+    'activationDate',
+    'active',
+    // The parameters is an array and needs at least one item.
+    // If it passes the check means that it is not null, and because of the
+    // schema validation can be considered valid.
+    'parameters'
+  ];
+  const instCounts = inst.reduce((totals, child) => {
+    let req = instrumentsSimpleChecks.length;
+    let actual = instrumentsSimpleChecks.reduce((c, prop) => c + checkProp(prop, child), 0);
+
+    // If is not active we need the deativation date.
+    if (child.active === false) {
+      req++;
+      actual += checkProp('deactivationDate', child);
+    }
+
+    return {
+      req: totals.req + req,
+      actual: totals.actual + actual
+    };
+  }, { req: 0, actual: 0 });
+
+  // There is a minimum required props for the instruments, but in the end it
+  // also depends on children.
+  requiredPropCount += Math.max(instrumentsSimpleChecks.length, instCounts.req);
+  actualPropCount += instCounts.actual;
+
+  return actualPropCount / requiredPropCount;
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -246,7 +246,8 @@ export function buildLocationsWhere (query) {
     radius,
     metadata,
     siteType,
-    activationDate
+    activationDate,
+    completeness
   } = query;
 
   return builder => {
@@ -324,6 +325,13 @@ export function buildLocationsWhere (query) {
         [start, end] = start > end ? [end, start] : [start, end];
 
         builder.whereRaw("data->>'activationDate' BETWEEN :start AND :end", { start, end });
+      }
+
+      if (completeness) {
+        const [ min, max ] = completeness;
+        // Ensure order.
+        const range = min > max ? [max, min] : [min, max];
+        builder.whereBetween('completeness', range);
       }
     } // End metadata properties.
   };

--- a/migrations/20190508154837_create_latest_locations_metadata_view.js
+++ b/migrations/20190508154837_create_latest_locations_metadata_view.js
@@ -24,6 +24,6 @@ exports.up = function (knex, Promise) {
 
 exports.down = function (knex, Promise) {
   return knex.schema.raw(`
-    DROP VIEW latest_locations_metadata IF EXISTS
+    DROP VIEW IF EXISTS latest_locations_metadata
   `);
 };

--- a/migrations/20190625152214_locations-metadata-completeness.js
+++ b/migrations/20190625152214_locations-metadata-completeness.js
@@ -1,0 +1,11 @@
+exports.up = function (knex, Promise) {
+  return knex.schema.table('locations_metadata', (table) => {
+    table.float('completeness');
+  });
+};
+
+exports.down = function (knex, Promise) {
+  return knex.schema.table('locations_metadata', (table) => {
+    table.dropColumn('completeness');
+  });
+};

--- a/migrations/20190625153937_completeness-latest-locations-metadata-view.js
+++ b/migrations/20190625153937_completeness-latest-locations-metadata-view.js
@@ -1,0 +1,55 @@
+exports.up = async function (knex, Promise) {
+  await knex.schema.raw(`
+    DROP VIEW IF EXISTS latest_locations_metadata
+  `);
+  return knex.schema.raw(`
+    CREATE VIEW latest_locations_metadata AS
+    SELECT
+      locations_metadata.id,
+      locations_metadata."locationId",
+      locations_metadata."userId",
+      locations_metadata.data,
+      locations_metadata.completeness,
+      lm."createdAt",
+      lm."updatedAt",
+      lm.version
+    FROM locations_metadata
+    INNER JOIN (
+      SELECT
+        "locationId",
+        max("createdAt") as "updatedAt",
+        min("createdAt") as "createdAt",
+        COUNT("locationId") as version
+      FROM locations_metadata
+      GROUP BY "locationId"
+    ) lm ON locations_metadata."locationId" = lm."locationId" AND locations_metadata."createdAt" = lm."updatedAt"
+  `);
+};
+
+exports.down = async function (knex, Promise) {
+  await knex.schema.raw(`
+    DROP VIEW IF EXISTS latest_locations_metadata
+  `);
+
+  return knex.schema.raw(`
+    CREATE VIEW latest_locations_metadata AS
+    SELECT
+      locations_metadata.id,
+      locations_metadata."locationId",
+      locations_metadata."userId",
+      locations_metadata.data,
+      lm."createdAt",
+      lm."updatedAt",
+      lm.version
+    FROM locations_metadata
+    INNER JOIN (
+      SELECT
+        "locationId",
+        max("createdAt") as "updatedAt",
+        min("createdAt") as "createdAt",
+        COUNT("locationId") as version
+      FROM locations_metadata
+      GROUP BY "locationId"
+    ) lm ON locations_metadata."locationId" = lm."locationId" AND locations_metadata."createdAt" = lm."updatedAt"
+  `);
+};

--- a/seeds/locations-metadata.js
+++ b/seeds/locations-metadata.js
@@ -1,0 +1,84 @@
+const locations = require('../test/data/locations.json');
+const { computeCompleteness } = require('../lib/location-metadata-schema');
+
+exports.seed = async function (knex, Promise) {
+  // Clear table
+  await knex.delete().from('locations_metadata');
+  await knex.raw('ALTER SEQUENCE locations_metadata_id_seq RESTART WITH 1');
+
+  const userId = 'test|12345';
+
+  let inserts = [];
+
+  // For the first location let's insert a complete record
+  const doc = {
+    locationId: locations[0].id,
+    userId,
+    createdAt: locations[0].firstUpdated,
+    data: {
+      name: locations[0].sourceName,
+      instruments: [
+        {
+          type: 'test-instrument',
+          active: true,
+          parameters: locations[0].countsByMeasurement.map(o => o.parameter),
+          serialNumber: 'abc5',
+          manufacturer: 'openaq',
+          modelName: 'az-05',
+          measurementStyle: 'automated',
+          rawFrequency: 5000,
+          reportingFrequency: 7500,
+          calibrationProcedures: 'none',
+          inletHeight: 1,
+          activationDate: locations[0].firstUpdated
+        }
+      ],
+      siteType: 'rural',
+      sourceType: locations[0].sourceType,
+      elevation: 12,
+      activationDate: locations[0].firstUpdated,
+      active: true,
+      attribution: [
+        {
+          name: 'Open AQ',
+          url: 'http://openaq.org'
+        }
+      ],
+      coordinates: {
+        latitude: locations[0].coordinates.latitude,
+        longitude: locations[0].coordinates.longitude
+      }
+    }
+  };
+  inserts.push(Object.assign({}, doc, {
+    completeness: computeCompleteness(doc.data)
+  }));
+
+  // For half the other locations, let's use the base minimum.
+  for (let i = 1; i < Math.floor(locations.length / 2); i++) {
+    const doc = {
+      locationId: locations[i].id,
+      userId,
+      createdAt: locations[i].firstUpdated,
+      data: {
+        name: locations[i].sourceName,
+        active: true,
+        instruments: [
+          {
+            type: 'test-instrument',
+            active: true,
+            parameters: locations[i].countsByMeasurement.map(o => o.parameter),
+            serialNumber: `num-${locations[i].id}`
+          }
+        ],
+        siteType: ['rural', 'urban', 'suburban', 'unlabeled'][i % 4],
+        activationDate: locations[i].firstUpdated
+      }
+    };
+    inserts.push(Object.assign({}, doc, {
+      completeness: computeCompleteness(doc.data)
+    }));
+  }
+
+  await knex.batchInsert('locations_metadata', inserts);
+};

--- a/seeds/locations.js
+++ b/seeds/locations.js
@@ -9,14 +9,9 @@ exports.seed = async function (knex, Promise) {
   // Clean up locations table
   await knex('locations').del();
 
-  for (let l of locations) {
-    // Generate WKT from coordinates, if available
-    if (isNumber(l.coordinates.longitude) && isNumber(l.coordinates.latitude)) {
-      l.coordinates = `POINT(${l.coordinates.longitude} ${l.coordinates.latitude})`;
-    }
-
+  const data = locations.map(loc => {
     // Pick allowed location properties
-    l = pick(l, [
+    let l = pick(loc, [
       'id',
       'cities',
       'city',
@@ -36,13 +31,15 @@ exports.seed = async function (knex, Promise) {
       'sourceType',
       'sourceTypes'
     ]);
-  }
 
-  // Create array of inserts tasks
-  let tasks = locations.map(m => {
-    return knex('locations').insert(m);
+    // Generate WKT from coordinates, if available
+    if (isNumber(l.coordinates.longitude) && isNumber(l.coordinates.latitude)) {
+      l.coordinates = `POINT(${l.coordinates.longitude} ${l.coordinates.latitude})`;
+    }
+
+    return l;
   });
 
-  // Handle all tasks
-  return Promise.all(tasks);
+  // Create array of inserts tasks
+  return knex.batchInsert('locations', data);
 };

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -81,6 +81,52 @@ const scenarios = {
       }));
     }
 
+    // Include a complete one.
+    const doc = {
+      locationId: 'GB-10',
+      userId,
+      createdAt: '2019-02-02T00:00:00.000Z',
+      data: {
+        name: 'EEA Andorra',
+        active: true,
+        siteType: 'urban',
+        elevation: 12,
+        sourceType: 'government',
+        attribution: [
+          {
+            url: 'http://openaq.org',
+            name: 'Open AQ'
+          }
+        ],
+        coordinates: {
+          latitude: 42.50969,
+          longitude: 1.53914
+        },
+        instruments: [
+          {
+            type: 'test-instrument',
+            active: true,
+            modelName: 'az-05',
+            parameters: [
+              'co'
+            ],
+            inletHeight: 1,
+            manufacturer: 'openaq',
+            rawFrequency: 5000,
+            serialNumber: 'abc5',
+            activationDate: '2017-09-13T21:00:00.000Z',
+            measurementStyle: 'automated',
+            reportingFrequency: 7500,
+            calibrationProcedures: 'none'
+          }
+        ],
+        activationDate: '2017-09-13T21:00:00.000Z'
+      }
+    };
+    inserts.push(Object.assign({}, doc, {
+      completeness: computeCompleteness(doc.data)
+    }));
+
     await db.batchInsert('locations_metadata', inserts);
   },
 

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -7,6 +7,7 @@ import {
   upsertLocations,
   upsertCities
 } from '../../api/services/athena-sync';
+import { computeCompleteness } from '../../lib/location-metadata-schema';
 
 /* global fixturesPath */
 
@@ -56,7 +57,7 @@ const scenarios = {
 
     let inserts = [];
     for (let i = 0; i < 100; i++) {
-      inserts.push({
+      const doc = {
         // Ensure 2 entries per location.
         locationId: `GB-${Math.floor(i / 2) + 1}`,
         userId,
@@ -74,7 +75,10 @@ const scenarios = {
           siteType: ['rural', 'urban', 'suburban', 'unlabeled'][Math.floor(i / 2) % 4],
           activationDate: new Date(dateStart + i * 86400000)
         }
-      });
+      };
+      inserts.push(Object.assign({}, doc, {
+        completeness: computeCompleteness(doc.data)
+      }));
     }
 
     await db.batchInsert('locations_metadata', inserts);

--- a/test/test-locations.js
+++ b/test/test-locations.js
@@ -8,7 +8,6 @@ import fixtures from './fixtures';
 describe('/locations', function () {
   before(async function () {
     await fixtures('locations-2016');
-    await fixtures('locations-metadata');
   });
 
   it('should return properly', function (done) {
@@ -265,6 +264,13 @@ describe('/locations', function () {
       }
     );
   });
+});
+
+describe('/locations?metadata=true', function () {
+  before(async function () {
+    await fixtures('locations-2016');
+    await fixtures('locations-metadata');
+  });
 
   it('includes metadata when flag is passed', done => {
     request(
@@ -275,6 +281,10 @@ describe('/locations', function () {
 
         const res = JSON.parse(body);
         expect(res.results[0].metadata).to.be.null;
+        expect(res.results[0].metadataVersion).to.be.null;
+        expect(res.results[0].metadataUserId).to.be.null;
+        expect(res.results[0].metadataUpdatedAt).to.be.null;
+        expect(res.results[0].metadataCompleteness).to.be.null;
         expect(res.results[1].metadata).to.deep.equal({
           name: 'meta-87',
           instruments: [
@@ -288,6 +298,10 @@ describe('/locations', function () {
           siteType: 'unlabeled',
           activationDate: '2019-03-29T00:00:00.000Z'
         });
+        expect(res.results[1].metadataVersion).to.equal('2');
+        expect(res.results[1].metadataUserId).to.equal('test|12345');
+        expect(res.results[1].metadataUpdatedAt).to.equal('2019-01-01T00:01:27.000Z');
+        expect(res.results[1].metadataCompleteness).to.equal(0.318182);
         done();
       }
     );
@@ -302,7 +316,15 @@ describe('/locations', function () {
 
         const res = JSON.parse(body);
         expect(res.results[0]).to.not.have.property('metadata');
+        expect(res.results[0]).to.not.have.property('metadataVersion');
+        expect(res.results[0]).to.not.have.property('metadataUserId');
+        expect(res.results[0]).to.not.have.property('metadataUpdatedAt');
+        expect(res.results[0]).to.not.have.property('metadataCompleteness');
         expect(res.results[1]).to.not.have.property('metadata');
+        expect(res.results[1]).to.not.have.property('metadataVersion');
+        expect(res.results[1]).to.not.have.property('metadataUserId');
+        expect(res.results[1]).to.not.have.property('metadataUpdatedAt');
+        expect(res.results[1]).to.not.have.property('metadataCompleteness');
         done();
       }
     );
@@ -356,7 +378,7 @@ describe('/locations', function () {
     );
   });
 
-  it('returns locations between given activationDate regardless of datr order', done => {
+  it('returns locations between given activationDate regardless order', done => {
     request(
       `${apiUrl}locations?metadata=true&activationDate=2019-01-04T01:00:00.000Z&activationDate=2019-01-01T00:00:00.000Z`,
       (err, response, body) => {
@@ -367,6 +389,50 @@ describe('/locations', function () {
         expect(res.meta.found).to.equal(2);
         expect(res.results[0].metadata.activationDate).to.equal('2019-01-04T00:00:00.000Z');
         expect(res.results[1].metadata.activationDate).to.equal('2019-01-02T00:00:00.000Z');
+        done();
+      }
+    );
+  });
+
+  it('returns locations between given completeness', done => {
+    request(
+      `${apiUrl}locations?metadata=true&completeness=0.5&completeness=1`,
+      (err, response, body) => {
+        expect(err).to.be.null;
+        expect(response.statusCode).to.equal(200);
+
+        const res = JSON.parse(body);
+        expect(res.meta.found).to.equal(1);
+        expect(res.results[0].metadataCompleteness).to.equal(1);
+        done();
+      }
+    );
+  });
+
+  it('returns locations between given completeness 2', done => {
+    request(
+      `${apiUrl}locations?metadata=true&completeness=0.1&completeness=0.2`,
+      (err, response, body) => {
+        expect(err).to.be.null;
+        expect(response.statusCode).to.equal(200);
+
+        const res = JSON.parse(body);
+        expect(res.meta.found).to.equal(0);
+        done();
+      }
+    );
+  });
+
+  it('returns locations between given completeness regardless order', done => {
+    request(
+      `${apiUrl}locations?metadata=true&completeness=1&completeness=0.5`,
+      (err, response, body) => {
+        expect(err).to.be.null;
+        expect(response.statusCode).to.equal(200);
+
+        const res = JSON.parse(body);
+        expect(res.meta.found).to.equal(1);
+        expect(res.results[0].metadataCompleteness).to.equal(1);
         done();
       }
     );
@@ -386,6 +452,10 @@ describe('/locations/:id', function () {
 
       const res = JSON.parse(body);
       expect(res).to.not.have.property('metadata');
+      expect(res).to.not.have.property('metadataVersion');
+      expect(res).to.not.have.property('metadataUserId');
+      expect(res).to.not.have.property('metadataUpdatedAt');
+      expect(res).to.not.have.property('metadataCompleteness');
       done();
     });
   });

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import * as utils from '../lib/utils';
+import { computeCompleteness } from '../lib/location-metadata-schema';
 
 describe('utils', function () {
   describe('payloadToKey', function () {
@@ -249,6 +250,201 @@ describe('utils', function () {
       };
       expect(utils.isGeoPayloadOK(payload)).to.be.false;
       done();
+    });
+  });
+
+  describe('computeCompleteness', function () {
+    it('should return 0 if empty object is given', function () {
+      const doc = {
+      };
+      expect(computeCompleteness(doc)).to.equal(0);
+    });
+
+    it('should return correct value taking into account the minimum number of required properties', function () {
+      // See function definition for information on this.
+      const doc = {
+        name: 'EEA Andorra'
+      };
+      expect(computeCompleteness(doc)).to.equal(1 / 22);
+    });
+
+    it('should return correct value for required properties', function () {
+      // See function definition for information on this.
+      const doc = {
+        name: 'EEA Andorra',
+        instruments: [
+          {
+            type: 'test-instrument',
+            parameters: ['co'],
+            serialNumber: 'none'
+          }
+        ]
+      };
+      expect(computeCompleteness(doc)).to.equal(4 / 22);
+    });
+
+    it('should return 100% when all properties are provided', function () {
+      const doc = {
+        name: 'EEA Andorra',
+        active: true,
+        siteType: 'rural',
+        elevation: 12,
+        sourceType: 'government',
+        attribution: [
+          {
+            url: 'http://openaq.org',
+            name: 'Open AQ'
+          }
+        ],
+        coordinates: {
+          latitude: 42.50969,
+          longitude: 1.53914
+        },
+        instruments: [
+          {
+            type: 'test-instrument',
+            active: true,
+            modelName: 'az-05',
+            parameters: [
+              'co'
+            ],
+            inletHeight: 1,
+            manufacturer: 'openaq',
+            rawFrequency: 5000,
+            serialNumber: 'abc5',
+            activationDate: '2017-09-13T21:00:00.000Z',
+            measurementStyle: 'automated',
+            reportingFrequency: 7500,
+            calibrationProcedures: 'none'
+          }
+        ],
+        activationDate: '2017-09-13T21:00:00.000Z'
+      };
+      expect(computeCompleteness(doc)).to.equal(1);
+    });
+
+    it('should not return 100% when the active is false and there is no deactivationDate', function () {
+      // deactivationDate only counts for completeness if active is false
+      const doc = {
+        name: 'EEA Andorra',
+        active: false,
+        siteType: 'rural',
+        elevation: 12,
+        sourceType: 'government',
+        attribution: [
+          {
+            url: 'http://openaq.org',
+            name: 'Open AQ'
+          }
+        ],
+        coordinates: {
+          latitude: 42.50969,
+          longitude: 1.53914
+        },
+        instruments: [
+          {
+            type: 'test-instrument',
+            active: true,
+            modelName: 'az-05',
+            parameters: [
+              'co'
+            ],
+            inletHeight: 1,
+            manufacturer: 'openaq',
+            rawFrequency: 5000,
+            serialNumber: 'abc5',
+            activationDate: '2017-09-13T21:00:00.000Z',
+            measurementStyle: 'automated',
+            reportingFrequency: 7500,
+            calibrationProcedures: 'none'
+          }
+        ],
+        activationDate: '2017-09-13T21:00:00.000Z'
+      };
+      expect(computeCompleteness(doc)).to.equal(0.9565217391304348);
+    });
+
+    it('should not return 100% when the active is false and there is no deactivationDate inside an instrument', function () {
+      // deactivationDate only counts for completeness if active is false
+      const doc = {
+        name: 'EEA Andorra',
+        active: true,
+        siteType: 'rural',
+        elevation: 12,
+        sourceType: 'government',
+        attribution: [
+          {
+            url: 'http://openaq.org',
+            name: 'Open AQ'
+          }
+        ],
+        coordinates: {
+          latitude: 42.50969,
+          longitude: 1.53914
+        },
+        instruments: [
+          {
+            type: 'test-instrument',
+            active: false,
+            modelName: 'az-05',
+            parameters: [
+              'co'
+            ],
+            inletHeight: 1,
+            manufacturer: 'openaq',
+            rawFrequency: 5000,
+            serialNumber: 'abc5',
+            activationDate: '2017-09-13T21:00:00.000Z',
+            measurementStyle: 'automated',
+            reportingFrequency: 7500,
+            calibrationProcedures: 'none'
+          }
+        ],
+        activationDate: '2017-09-13T21:00:00.000Z'
+      };
+      expect(computeCompleteness(doc)).to.equal(0.9565217391304348);
+    });
+
+    it('should return 100% when the active is false and there is a deactivationDate', function () {
+      // deactivationDate only counts for completeness if active is false
+      const doc = {
+        name: 'EEA Andorra',
+        active: false,
+        siteType: 'rural',
+        elevation: 12,
+        sourceType: 'government',
+        attribution: [
+          {
+            url: 'http://openaq.org',
+            name: 'Open AQ'
+          }
+        ],
+        coordinates: {
+          latitude: 42.50969,
+          longitude: 1.53914
+        },
+        instruments: [
+          {
+            type: 'test-instrument',
+            active: true,
+            modelName: 'az-05',
+            parameters: [
+              'co'
+            ],
+            inletHeight: 1,
+            manufacturer: 'openaq',
+            rawFrequency: 5000,
+            serialNumber: 'abc5',
+            activationDate: '2017-09-13T21:00:00.000Z',
+            measurementStyle: 'automated',
+            reportingFrequency: 7500,
+            calibrationProcedures: 'none'
+          }
+        ],
+        activationDate: '2017-09-13T21:00:00.000Z',
+        deactivationDate: '2018-09-13T21:00:00.000Z'
+      };
+      expect(computeCompleteness(doc)).to.equal(1);
     });
   });
 });


### PR DESCRIPTION
NOT TO MERGE

This is an experiment to calculate the completeness of a location's metadata.
Right now it checks and logs the completeness value when a new metadata payload is submitted. If this approach works, we can store the value in the db alongside the metadata.

This will result in 100% completeness. Just remove properties to get other values.
```
{
  "name": "meta-5",
  "instruments": [
    {
      "type": "test-instrument",
      "active": true,
      "parameters": [
        "o3"
      ],
      "serialNumber": "abc5",
      "manufacturer": "openaq",
      "modelName": "az-05",
      "measurementStyle": "automated",
      "rawFrequency": 5000,
      "reportingFrequency": 7500,
      "calibrationProcedures": "none",
      "inletHeight": 1,
      "activationDate": "2019-01-01T00:00:00.000Z"
    }
  ],
  "siteType": "rural",
  "sourceType": "government",
  "elevation": 12,
  "activationDate": "2019-01-01T00:00:00.000Z",
  "active": true,
  "attribution": [
    {
      "name": "Open AQ",
      "url": "http://openaq.org"
    }
  ],
  "coordinates": {
    "latitude": 0,
    "longitude": 0
  }
}
```

Let me know what you think @sethvincent 