### PR TITLE
add auth to custom-environment-variables

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -23,5 +23,10 @@
   },
   "defaultRequestLimit": "REQUEST_LIMIT",
   "port": "PORT",
-  "webhookKey": "WEBHOOK_KEY"
+  "webhookKey": "WEBHOOK_KEY",
+  "auth": {
+    "strategy": "AUTH_STRATEGY",
+    "audience": "AUTH_AUDIENCE",
+    "issuer": "AUTH_ISSUER"
+  }
 }


### PR DESCRIPTION
I believe we missed adding custom environment variables for the auth config.

@jflasher am I understanding this right that when deployed the api reads environment variables and then uses those in the config?

here's the config we would use for staging:

```
AUTH_STRATEGY="jwt"
AUTH_AUDIENCE="https://openaq-staging.auth0.com/api/v2/"
AUTH_ISSUER="https://openaq-staging.auth0.com"
```

@danielfdsilva I think I've got this right but it could use a double check.