### PR TITLE
[WIP] Fix ordering countries by name

### DIFF
--- a/test/test-countries.js
+++ b/test/test-countries.js
@@ -84,6 +84,34 @@ describe('/countries', function () {
     );
   });
 
+  it('country name can be ordered in ascendant order', done => {
+    request(
+      `${apiUrl}countries?order_by=name&sort=asc`,
+      (err, response, body) => {
+        expect(err).to.be.null;
+        expect(response.statusCode).to.equal(200);
+
+        const res = JSON.parse(body);
+        expect(res.results).to.deep.equal(orderBy(res.results, 'name', 'asc'));
+        done();
+      }
+    );
+  });
+
+  it('country name can be ordered in descendant order', done => {
+    request(
+      `${apiUrl}countries?order_by=name&sort=desc`,
+      (err, response, body) => {
+        expect(err).to.be.null;
+        expect(response.statusCode).to.equal(200);
+
+        const res = JSON.parse(body);
+        expect(res.results).to.deep.equal(orderBy(res.results, 'name', 'desc'));
+        done();
+      }
+    );
+  });
+
   it('can be ordered by multiple fields and directions', done => {
     request(
       `${apiUrl}countries?order_by[]=cities&order_by[]=locations&sort[]=asc&sort[]=desc`,


### PR DESCRIPTION
I've added tests for the issue described at #412. I wanted to discuss the approach before pushing a fix.

After the unique location ids refactor, the API is querying the `cities` table to build the country list. This table only includes country codes, as their names are added after the query from country.json file. That's why it is not possible to order by names now.

I see two ways of solving this. The more straightforward would be creating countries table in the db and perform a join query sorting by country name. Another possible solution would be adding a where clause with country codes from the JSON file, but it will be trickier to apply `limit` and pagination.

@jflasher, please let me know what do you think.

cc @olafveerman 

