### PR TITLE
Updating how active Athena aggregations are checked

### DIFF
--- a/api/services/athena.js
+++ b/api/services/athena.js
@@ -18,6 +18,7 @@ class AthenaClient {
     this.submitQuery = pify(o.submitQuery.bind(o));
     this.getQueryResults = pify(o.getQueryResults.bind(o));
     this.fetchesTable = opts.fetchesTable;
+    this._client = o.athena;
   }
 
   _getAllResults (queryId) {


### PR DESCRIPTION
This should fix https://github.com/openaq/openaq.org/issues/346.

It gets the 10 most recent Athena queries, checks to see if any of them are currently running or queued, then checks to see if they match one of our aggregation queries. If they do, we do not run anymore.

This pattern should work no matter how many instances the API we have running and avoid any variable scope issues.