### PR TITLE
Docker tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,49 +1,16 @@
-FROM ubuntu:14.04
+FROM node:10-alpine
 
-# Replace shell with bash so we can source files
-RUN rm /bin/sh && ln -s /bin/bash /bin/sh
-
-# Set debconf to run non-interactively
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
-
-# Install base dependencies
-RUN apt-get update && apt-get install -y -q --no-install-recommends \
-        apt-transport-https \
-        build-essential \
-        ca-certificates \
-        curl \
-        git \
-        libssl-dev \
-        python \
-        rsync \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install nvm with node and npm
-# http://stackoverflow.com/questions/25899912/install-nvm-in-docker
-ENV NVM_DIR /usr/local/nvm
-RUN mkdir -p $NVM_DIR
-ENV NODE_VERSION 10
-RUN curl https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash \
-    && source $NVM_DIR/nvm.sh \
-    && nvm install $NODE_VERSION \
-    && nvm alias default $NODE_VERSION \
-    && nvm use default
-ENV PATH      $NVM_BIN:$PATH
-
-# Go ahead and install nodemon for convenience while developing
-RUN source $NVM_DIR/nvm.sh
-
-###########################
-# App-specific stuff
-
-# mongo uses kerberos
-RUN apt-get update && apt-get install -y libkrb5-dev
-
+RUN apk add python make g++
 # Install NPM dependencies. Do this first so that if package.json hasn't
 # changed we don't have to re-run npm install during `docker build`
 COPY package.json /app/package.json
 WORKDIR /app
-RUN source $NVM_DIR/nvm.sh; npm install
+RUN npm install
+
+FROM node:10-alpine
+
+WORKDIR /app
+COPY --from=0 /app /app
 # Copy the app
 COPY ["newrelic.js", ".eslintrc", ".eslintignore", ".babelrc", "knexfile.js", "index.js", "/app/"]
 COPY ["app.js", "/app/"]
@@ -54,10 +21,4 @@ COPY config /app/config/
 COPY migrations /app/migrations/
 COPY seeds /app/seeds/
 
-#############################
-# develop helper script and entrypoint
-#
-RUN source $NVM_DIR/nvm.sh
-ADD .build_scripts/entrypoint.sh /
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+CMD ["npm", "start"]

--- a/api/services/server.js
+++ b/api/services/server.js
@@ -220,7 +220,7 @@ Server.prototype.start = function (cb) {
   });
 
   self.hapi.start(function () {
-    self.hapi.log(['info'], 'Server running at:' + self.hapi.info.uri);
+    self.hapi.log(['info'], 'Server running at: ' + self.hapi.app.url);
     if (cb && typeof cb === 'function') {
       cb();
     }

--- a/config/development.json
+++ b/config/development.json
@@ -1,9 +1,9 @@
 {
   "knex": {
     "connection": {
-      "host": "localhost",
+      "host": "postgresql-dev",
       "user": "docker",
-      "port": "15432",
+      "port": "5432",
       "password": "docker",
       "database": "gis"
     }

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,5 +1,19 @@
 version: "3"
 services:
+  api:
+    environment:
+    - API_URL=http://localhost:3004
+    - PSQL_HOST=postgresql-dev
+    - PSQL_PORT=5432
+    - PSQL_USER=docker
+    - PSQL_PASSWORD=docker
+    - PSQL_DATABASE=gis
+    ports:
+    - "3004:3004"
+    links:
+    - postgresql-dev
+    restart: always
+    command: npm run dev
   postgresql-dev:
     image: kartoza/postgis:9.4-2.1
     command: sh -c "echo \"host all all 0.0.0.0/0 md5\" >> /etc/postgresql/9.4/main/pg_hba.conf && /start-postgis.sh"
@@ -7,3 +21,10 @@ services:
       - "15432:5432"
     volumes:
       - ./data/postgresql-dev:/var/lib/postgresql
+  pgadmin:
+    image: dpage/pgadmin4
+    ports:
+      - "8080:80"
+    environment:
+      - PGADMIN_DEFAULT_EMAIL=user@example.com
+      - PGADMIN_DEFAULT_PASSWORD=Secret111

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,22 @@
-api:
-  build: .
-  volumes:
-  - .:/local
-  env_file: ./local.env
-  ports:
-  - "80:3004"
-api-test:
-  build: .
-  volumes:
-  - .:/local
-  environment:
-  - PSQL_HOST=postgis
-  - PSQL_USER=docker
-  - PSQL_PASSWORD=docker
-  - PSQL_DATABASE=gis
-  links:
-  - postgis
-postgis:
-  image: kartoza/postgis:9.4-2.1
+version: "3"
+services:
+  api:
+    build: .
+    volumes:
+    - .:/local
+    env_file: ./local.env
+    ports:
+    - "80:3004"
+  api-test:
+    build: .
+    volumes:
+    - .:/local
+    environment:
+    - PSQL_HOST=postgis
+    - PSQL_USER=docker
+    - PSQL_PASSWORD=docker
+    - PSQL_DATABASE=gis
+    links:
+    - postgis
+  postgis:
+    image: kartoza/postgis:9.4-2.1

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "good-winston": "^1.0.0",
     "hapi": "^8.8.0",
     "hapi-auth-jwt2": "^7.4.1",
-    "hapi-paginate": "github:developmentseed/hapi-paginate#cfa9067d634e2bcef9a631ee71646cc9dbf2f5f7",
+    "hapi-paginate": "^0.4.1",
     "hapi-response-meta": "^0.3.0",
     "hapi-router": "^3.0.1",
     "hiredis": "^0.4.1",


### PR DESCRIPTION
- API now uses smaller alpine node image
- Removed `nvm` usage - since the node image is already versioned
- Bump `hapi-paginate` to a new & concrete npm version (github://repo#sha sometimes didn't work)
- Add `pgadmin` for dev database exploration

Yet another docker PR 😄 Just some changes I made while trying to reproduce an issue.